### PR TITLE
re-theme: hookFactory update

### DIFF
--- a/repos/keg-components/src/components/button/button.wrapper.js
+++ b/repos/keg-components/src/components/button/button.wrapper.js
@@ -53,13 +53,13 @@ export const ButtonWrapper = props => {
   const [ hoverRef, hoverStyles ] = useThemeHover(
     get(btnStyles, 'default', {}),
     get(btnStyles, 'hover'),
-    { ref, noMerge: true }
+    { ref, noMerge: false }
   )
 
   const [ themeRef, themeStyles ] = useThemeActive(
     hoverStyles,
     get(btnStyles, 'active'),
-    { ref: hoverRef, noMerge: true }
+    { ref: hoverRef, noMerge: false }
   )
 
   return (

--- a/repos/keg-components/src/components/button/button.wrapper.js
+++ b/repos/keg-components/src/components/button/button.wrapper.js
@@ -53,13 +53,13 @@ export const ButtonWrapper = props => {
   const [ hoverRef, hoverStyles ] = useThemeHover(
     get(btnStyles, 'default', {}),
     get(btnStyles, 'hover'),
-    { ref, noMerge: false }
+    { ref }
   )
 
   const [ themeRef, themeStyles ] = useThemeActive(
     hoverStyles,
     get(btnStyles, 'active'),
-    { ref: hoverRef, noMerge: false }
+    { ref: hoverRef }
   )
 
   return (

--- a/repos/re-theme/src/hooks/hookFactory.js
+++ b/repos/re-theme/src/hooks/hookFactory.js
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useCallback, useLayoutEffect } from 'react'
 import { isFunc, isObj, isColl, deepMerge, checkCall } from '@svkeg/jsutils'
 import { Constants } from '../constants'
 
@@ -141,11 +141,19 @@ export const hookFactory = events =>
     const hookRef = ref || useRef()
     // Set the default value as off
     const [ value, setValue ] = useState(offValue)
+    const [ valueOn, setValueOn ] = useState(onValue)
 
     // Set default joinedOnOff, to allow comparing against later
-    const [activeValue] = useState(
-      checkJoinValues(offValue, onValue, onValue, noMerge)
+    const [ activeValue, setActiveValue ] = useState(
+      checkJoinValues(offValue, valueOn, valueOn, noMerge)
     )
+
+    useLayoutEffect(() => {
+      if (onValue !== valueOn) {
+        setValueOn(onValue)
+        setActiveValue(checkJoinValues(offValue, onValue, onValue, noMerge))
+      }
+    }, [ onValue, valueOn, offValue, noMerge ])
 
     // Create the callback ref ( i.e. function ref )
     // Which gets the node the ref is attached to as an argument


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-280)

## Context

* There's a bug in hookFactory where it does not update the `activeValue`. which causes the button component to not update its styles on **hover** and **active** state
* ![keg-comp](https://user-images.githubusercontent.com/3317835/92023863-3a357e80-ed12-11ea-9494-b882fe31c95c.gif)


## Goal

* Update `hookFactory` so that it updates `activeValue` whenever there is a change to it
* also update keg-components Button, so that it merges the styles for active and hover states

## Updates

- updated button component to **merge** the styles for hoverStyles and activeStyles
- updated re-theme: **hookFactory** to update the activeValue when it changes

## Testing

* run `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-280-groupbooking-modal-footer web`
* navigate to http://kegdev.xyz/test
* open one of the `Group Booking Modal` 1,2 or 3
* resize your browser to mobile size < 480px
* see that the fontSize of the button changed
* hover over either buttons, verify that the fontSize remains the same as the default


### Unit test
* Pull the branch `gh pr checkout 9`
* run `yarn test` on keg-components and re-theme to verify that it still passes