### PR TITLE
keg-core: rename eventEmitter to eventListener

### DIFF
--- a/repos/keg-core/core/base/utils/events/eventListener.js
+++ b/repos/keg-core/core/base/utils/events/eventListener.js
@@ -1,14 +1,14 @@
 import { logData } from '@keg-hub/jsutils'
 
-let KegEventEmitter
+let KegEventListener
 
 /**
  * Stores events based on event names, which can then be called at another time in a different location
  *
  * @export
- * @class EventEmitter
+ * @class EventListener
  */
-export class EventEmitter {
+export class EventListener {
   listeners = {}
 
   on = (event, cb) => {
@@ -42,10 +42,10 @@ export class EventEmitter {
 /**
  * Gets the App Event Emitter, if one does not exist it creates it
  *
- * @returns {EventEmitter|Object} - Instance of an EventEmitter
+ * @returns {EventListener|Object} - Instance of an EventListener
  */
-export const getEventEmitter = () => {
-  KegEventEmitter = KegEventEmitter || new EventEmitter()
+export const getEventListener = () => {
+  KegEventListener = KegEventListener || new EventListener()
 
-  return KegEventEmitter
+  return KegEventListener
 }

--- a/repos/keg-core/core/base/utils/events/index.js
+++ b/repos/keg-core/core/base/utils/events/index.js
@@ -1,1 +1,1 @@
-export * from 'SVUtils/events/event_emitter'
+export * from 'SVUtils/events/eventListener'


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-280)

## Context

- we're using the `eventEmitter` util class in the tap now
- the name `eventListener` makes more sense than `eventEmitter`
- update the name 

## Goal

- renaming eventEmitter to eventListener

    

## Updates

`repos/keg-core/core/base/utils/events/eventListener.js`
- renamed from `eventEmitter` to `eventListener`


## Testing
* No functionality changes so there's nothing to test