### PR TITLE
retheme: Use pointer events

### DIFF
--- a/repos/re-theme/src/hooks/useThemeHover.js
+++ b/repos/re-theme/src/hooks/useThemeHover.js
@@ -3,9 +3,9 @@
 import { hookFactory } from './hookFactory'
 
 /**
- * Creates an useThemeHover hook based on the 'mouseenter' and 'mouseleave' events
+ * Creates an useThemeHover hook based on the 'pointerover' and 'pointerout' events
  */
 export const useThemeHover = hookFactory({
-  on: 'mouseenter',
-  off: 'mouseleave',
+  on: 'pointerover',
+  off: 'pointerout',
 })


### PR DESCRIPTION
**Ticket**: https://jira.simpleviewtools.com/browse/ZEN-365

## Context

* on native mobile browser, tapping on the buttons keeps them on the hover state

## Goal
* update retheme `useThemeHover` to use pointer events instead of mouse

## Updates

* `repos/re-theme/src/hooks/useThemeHover.js`
   - use pointer events instead of mouse


## Testing

* Run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:fix-hover-issues-on-mobile command:sb`
* verify that the button components still functions as before

* Run `keg d tunnel`
* scan the QR code and load the app on your phone
* go to a Button story
* verify that when you tap on the buttons, they don't get stuck on the 'hover' color (aka goes back to default color after tap)