### PR TITLE
Syntax error fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+**Ticket**: [issue_id](link_to_jira_ticket)
+
+## Context
+
+* Why was this ticket created?
+
+## Goal
+
+* What do you intend to achieve by completing this task?
+
+## Updates
+
+* List the updates you made to the codebase. Use your best judgement on how detailed the description should be
+* *Name of file modified*
+  * What changed in this file? Why?
+
+## Testing
+
+* List out the steps you took to test your changes
+* Use the template below for listing out your testing steps
+  ```
+    * <Function> Testing:
+      * Step 1
+      * Step 2
+      * Step n
+      * Verify <some_expectations>
+  ```
+* Example Search Testing:
+  * login to zsales.zerista.com as admin
+  * Click on the 'Speakers' tab
+  * Search for 'billy bob'
+  * Verify that the speaker user shows up

--- a/repos/keg-components/configs/babel.config.js
+++ b/repos/keg-components/configs/babel.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const { resolvedAlias } = require('./aliases.config')
 
 module.exports = {
-  presets: [ '@babel/env', '@babel/preset-react' ],
+  presets: [ '@babel/preset-env', '@babel/preset-react' ],
   plugins: [
     [ '@babel/plugin-proposal-class-properties' ],
     [ 'module-resolver', {

--- a/repos/keg-components/package.json
+++ b/repos/keg-components/package.json
@@ -28,7 +28,7 @@
     "clean:nm": "rimraf yarn.lock; rimraf package.lock; rimraf node_modules",
     "clean:install": "yarn clean:full; yarn install --force",
     "copy:indexes": "cp ./index.cjs.js build/cjs/index.js; cp ./index.esm.js build/esm/index.js",
-    "dev": "nodemon --watch ./configs --exec 'rollup -c ./configs/rollup.config.js -w'",
+    "dev": "nodemon --watch ./configs --exec 'NODE_ENV=production rollup -c ./configs/rollup.config.js -w'",
     "eslint:watch": "onchange '**/*.{js,jsx}' -- eslint --config ./configs/eslint.config.js {{changed}} --fix",
     "format:eslint": "eslint --config ./configs/eslintrc.config.js . --fix --quiet",
     "format:prettier": "prettier --config ./configs/prettier.config.js --ignore-path .eslintignore --write '**/*.{js,jsx}'",


### PR DESCRIPTION
## Context

* When using `keg-components` in a development workflow inside docker, with the `yarn dev` command, the optional chaining operator `?.` was not getting compiled

## Goal

* fix this issue
* also add a PR template at the root of the monorepo, since there isn't one

## Updates

* `.github/PULL_REQUEST_TEMPLATE.md`
  * added the template
* `repos/keg-components/configs/babel.config.js`
  * just updated the name of the babel preset-env preset to be `preset-env` instead of `env`. This does nothing different, since babel prepends `preset` to any preset without that prefix already, but it's more clear
* `repos/keg-components/package.json`
  * added `NODE_ENV=production` to the dev command, so that `?.` gets compiled


## Testing

* `keg pr 19`
* `keg components`
* `yarn dev`
* open `build/esm/kegComponents.native.js` or any other build file
* search the file for any instance of `?.`. Verify there are zero such instances.

### Container testing
* `keg core start`
* `keg core sync components:install:start`
* `keg core start`
* verify that you can open the keg test page at `kegdev.xyz` and you see no errors about the syntax in the terminal output
