### PR TITLE
update url to local

### DIFF
--- a/repos/keg-cli/src/constants/constants.js
+++ b/repos/keg-cli/src/constants/constants.js
@@ -100,7 +100,7 @@ module.exports = deepFreeze({
   ],
 
   // URLs for navigating to the application
-  TAP_URL: `http://tap.kegdev.xyz/`,
+  TAP_URL: `http://tap.local.kegdev.xyz/`,
 
   // ENV port to map to port 80 inside the docker container
   HTTP_PORT_ENV: `DOC_APP_PORT`,


### PR DESCRIPTION
## Context

* after keg-hub docker desktop update
* after running any container. it still prints this text out
     * ![image](https://user-images.githubusercontent.com/3317835/92950685-ef9ebb00-f411-11ea-835c-8df3afd5e2b8.png)
* we cant hit that url
* it should be `<context>.local.kegdev.xyz`


## Goal

* update the constant so it displays the correct url

## Updates

* `repos/keg-cli/src/constants/constants.js`
    * updated the url to `http://tap.local.kegdev.xyz/`

## Testing

* pull this branch
* Run a container i.e:
    * `keg evf start`
    * `keg components start`
* see that the served url is something like 
   * `http://<context>.local.kegdev.xyz/`
   * ![image](https://user-images.githubusercontent.com/3317835/92951197-d8140200-f412-11ea-8305-bee2e7095f2c.png)
* verify that you can navigate to that url
    
