### PR TITLE
Keg push force option fix

### DIFF
--- a/repos/keg-cli/src/libs/git/branch.js
+++ b/repos/keg-cli/src/libs/git/branch.js
@@ -1,9 +1,8 @@
 const { Logger } = require('KegLog')
 const { gitCli, gitCmd } = require('./commands')
 const { checkCall } = require('@keg-hub/jsutils')
-const { buildCmdOpts, ensureGitRemote, ensureGitBranch } = require('./helpers')
 const { NEWLINES_MATCH, WHITESPACE_MATCH } = require('KegConst/patterns')
-
+const { buildCmdOpts, ensureGitRemote, ensureGitBranch } = require('./helpers')
 /**
  * Matches any * or - character that does not have a alphanumeric character following it
  * @example
@@ -103,6 +102,8 @@ const doGitAction = async (git, action, args, cmdOpts) => {
   if(!withBranch) return { data: `Failed to find branch to push to!`, exitCode: 1 }
   
   toRun.push(withBranch)
+
+  args.force && toRun.push('--force')
 
   const resp = await gitCmd(toRun, buildCmdOpts(cmdOpts, args))
 

--- a/repos/keg-cli/src/tasks/git/push.js
+++ b/repos/keg-cli/src/tasks/git/push.js
@@ -1,5 +1,6 @@
 const { Logger } = require('KegLog')
 const { git } = require('KegGitCli')
+const { ask } = require('@keg-hub/ask-it')
 const { exists } = require('@keg-hub/jsutils')
 const { getGitPath } = require('KegUtils/git')
 const { generalError } = require('KegUtils/error')
@@ -19,7 +20,13 @@ const gitPushRepo = async args => {
   const { skipLog } = __internal
   const { context, location: repoPath, tap, env, log, ...pushParams } = params
   const location = repoPath || context && getGitPath(globalConfig, tap || context) || process.cwd()
+
+  const doPush = pushParams.force
+    ? await ask.confirm(`Are you sure you want to force push your local changes?`)
+    : true
   
+  if(!doPush) return Logger.log(`Canceled git push task!`)
+
   const { data, exitCode } = await git.branch.push({ ...pushParams, log: exists(skipLog) && !skipLog || log, location })
   
   // Log the outcome of the git push command


### PR DESCRIPTION
## Context

* git push --force option was not being used when passed for the `keg push` task

## Goal
* Update the `keg push` task to use the force option properly

## Updates
* Updated git push task to use the `force` option

## Testing
* Pull the branch
* Switch to a different git repo
* Check out a new branch on the repo
* Run the command `keg push --force`
  * It should ask if you are sure you want to force push the branch
  * Enter no
  * It should then cancel force pushing
* Run the command `keg push --force`
  * It should ask if you are sure you want to force push the branch
  * Enter yes
  * It should force push the branch to the origin remote
