### PR TITLE
Keg-Components className updates

### DIFF
--- a/repos/keg-components/src/hooks/useClassList.js
+++ b/repos/keg-components/src/hooks/useClassList.js
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
-import { eitherArr } from '@keg-hub/jsutils'
 import { noPropArr } from '../utils/helpers/noop'
+import { eitherArr } from '@keg-hub/jsutils'
+import { ensureClassArray } from '../utils/helpers/ensureClassArray'
 
 /**
  * Builds an array of classNames, memoizes then returns them
@@ -17,6 +18,6 @@ import { noPropArr } from '../utils/helpers/noop'
 export const useClassList = (className, classList = noPropArr) => {
   const classListArr = eitherArr(classList, [classList])
   return useMemo(() => {
-    return classListArr.concat([className])
+    return ensureClassArray(classListArr).concat([className])
   }, [ className, ...classListArr ])
 }

--- a/repos/keg-components/src/hooks/useClassName.js
+++ b/repos/keg-components/src/hooks/useClassName.js
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
-import { checkCall, eitherArr, isObj, isArr } from '@keg-hub/jsutils'
 import { getPlatform } from 'KegGetPlatform'
+import { checkCall, eitherArr, isObj } from '@keg-hub/jsutils'
+import { ensureClassArray } from '../utils/helpers/ensureClassArray'
+
 const isWeb = getPlatform() === 'web'
 
 /**
@@ -13,13 +15,13 @@ const isWeb = getPlatform() === 'web'
  *
  * @example
  * const classRef = useClassName('class-1', `class-2`, ref || React.createRef())
- * // The class attribute of the div will be `class-1 class-2` 
+ * // The class attribute of the div will be `class-1 class-2`
  * return (<div ref={classRef} />My Div</div>)
- * 
+ *
  * @returns {function} - Ref function to be added to the component
  */
 export const useClassName = (defClass, className, ref) => {
-  className = eitherArr(className, [className]) 
+  className = eitherArr(className, [className])
 
   return useCallback(
     element => {
@@ -27,8 +29,8 @@ export const useClassName = (defClass, className, ref) => {
         // Add the default classes to the classList
         defClass && element.classList.add(defClass)
 
-        // Add className to the classList
-        className.map(cls => cls && element.classList.add(cls))
+        // Ensure classNames is flat array, then add it's children
+        element.classList.add(...ensureClassArray(className))
       }
 
       // Update the ref based on it's type

--- a/repos/keg-components/src/hooks/useClassName.native.js
+++ b/repos/keg-components/src/hooks/useClassName.native.js
@@ -1,10 +1,7 @@
-import { useCallback } from 'react'
-import { checkCall, isObj } from '@keg-hub/jsutils'
-
 /**
  * Placeholder hook for Native platforms
  * <br/>Just returns the passed in ref
- * 
+ *
  * @returns {Object|function|undefeind} - Passed in Ref
  */
 export const useClassName = (defClass, className, ref) => {

--- a/repos/keg-components/src/utils/helpers/ensureClassArray.js
+++ b/repos/keg-components/src/utils/helpers/ensureClassArray.js
@@ -1,0 +1,28 @@
+import { eitherArr, isObj, isStr, isArr } from '@keg-hub/jsutils'
+
+/**
+ * Flattens the passed in class list into an single level array
+ * <br/>Converts any objects with className props or strings into individual array items
+ * @param {Array[*]} classList - List of classes to be flattened
+ * @param {Array[string]} ensured - The flattened className array
+ *
+ * @returns {Array[string]} ensured - The flattened className array
+ */
+export const ensureClassArray = (classList, ensured = []) => {
+  return eitherArr(classList, [classList]).reduce((classNames, item) => {
+    isObj(item)
+      ? item.className
+          ? ensureClassArray(item.className, classNames)
+          : // Loop over the item keys and call ensureClassArray if the item key values are objects
+          // Otherwise we can be added random strings to the classNames array
+          Object.keys(item).map(
+            key => isObj(item[key]) && ensureClassArray(item[key], classNames)
+          )
+      : isArr(item)
+        ? ensureClassArray(item, classNames)
+        : isStr(item) &&
+        item.split(' ').map(item => item && classNames.push(item))
+
+    return classNames
+  }, ensured)
+}


### PR DESCRIPTION
**Ticket**: [ZEN-355](https://jira.simpleviewtools.com/browse/ZEN-355)

## Context
* Keg Components should allow passing className in different formats


## Goal
* Allow passing classNames in different formats

## Updates
* `repos/keg-components/src/utils/helpers/ensureClassArray.js`
  * Added helper to parse passed in classNames
    * Allows pasing classNames in different formats
* `repos/keg-components/src/hooks/useClassName.native.js`
  * Cleaned up native version
* `repos/keg-components/src/hooks/useClassList.js` && `repos/keg-components/src/hooks/useClassName.js`
  * Updated class hooks to use the ensureClassListArray helper


## Testing
>Tests are the same as this pr => https://github.com/simpleviewinc/tap-events-force/pull/46
> So if you test that PR, you've tested this PR

* Run `keg dpg run docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-352-css-updates`
* Navigate to http://tap.local.kegdev.xyz/
* Ensure the tap runs properly


### Class Names with ef-* Prefix

**Session ClassNames**
* Right click > inspect on an item on the page
* Look over the dom tree and validate the `ef-*` classNames are being applied to the components
    * verify that they have a className with the `ef-` prefix
    * Here's an [example of what it should look like](http://snpy.in/ycfR0W)

**Modal ClassNames**
* Navigate to http://tap.local.kegdev.xyz/test
* Open each of the modals and validate the classNames exist with the `ef-*` prefix
    * Here's an [example of what it should look like](http://snpy.in/mPEQaH)
