### PR TITLE
Keg drawer component

### DIFF
--- a/repos/keg-components/src/components/box/textBox.stories.js
+++ b/repos/keg-components/src/components/box/textBox.stories.js
@@ -5,13 +5,17 @@ import { StoryWrap } from 'StoryWrap'
 import { Input } from 'KegInput'
 import { View } from 'react-native'
 
+const placeHolderText = 'Your text goes here...'
 const TextBoxStory = ({ type, useClipboard }) => {
-  const [ text, setText ] = useState('Your text goes here...')
+  const [ text, setText ] = useState(placeHolderText)
   const inputRef = useRef(null)
 
   useEffect(() => {
-    inputRef.current && inputRef.current.focus()
-    if (text !== 'Your text goes here...') inputRef.current.value = text
+    !inputRef.current &&
+      console.error(`Input ref did not get set. Something is wrong with the input component!`)
+    
+    inputRef.current.focus()
+    if (text !== placeHolderText) inputRef.current.value = text
   }, [text])
 
   return (

--- a/repos/keg-components/src/components/drawer/drawer.examples.js
+++ b/repos/keg-components/src/components/drawer/drawer.examples.js
@@ -1,0 +1,129 @@
+import React,  { useState, useMemo } from 'react'
+import { useStylesCallback } from '@keg-hub/re-theme'
+import { Drawer } from './drawer'
+import { Grid } from '../layout/grid'
+import { View } from '../view/view'
+import { Subtitle } from '../typography/subtitle'
+import { P } from '../typography/p'
+import { H5 } from '../typography/h5'
+import { Button } from '../button/button'
+import { ChevronDown } from '../../assets/icons'
+import { Icon } from 'KegIcon'
+
+const buildStyles = (theme, helpers) => {
+  const variant = helpers.toggled ? 'secondary' : 'primary'
+
+  return {
+    main: {
+      ...theme.flex.column,
+    },
+    toggle: {
+      main: {
+        ...theme.flex.center,
+        marginTop: theme.margin.size,
+        alignSelf: 'center'
+      },
+      button: {
+        main: {
+          padding: theme.padding.size / 2,
+          paddingHorizontal: theme.padding.size,
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }
+      },
+      icon: {
+        color: theme.colors.surface[variant].colors.dark,
+        marginRight: theme.margin.size / 3,
+        fontSize: 18,
+        transitionProperty: 'transform',
+        transitionDuration: '0.8s',
+        transform: helpers.toggled ? 'rotate(90deg)' : 'rotate(0deg)'
+      },
+      subtitle: {
+        color: theme.colors.surface[variant].colors.dark,
+        fontWeight: 'bold',
+      }
+    },
+    drawer: {},
+    content: {
+      main: {
+        padding: theme.padding.size * 2,
+        paddingBottom: theme.padding.size,
+        borderRadius: 5,
+        backgroundColor: theme.colors.opacity._5
+      }
+    }
+  }
+}
+
+const DrawerToggle = ({ toggled, onPress, styles }) => {
+  const action = toggled ? 'Hide' : 'See'
+  const variant = toggled ? 'secondary' : 'primary'
+  return (
+    <View style={styles.main} >
+      <Button
+        className='drawer-toggle'
+        themePath={`button.text.${variant}`}
+        styles={styles.button}
+        onPress={onPress}
+      >
+        <Icon
+          styles={styles.icon}
+          Component={ChevronDown}
+        />
+        <Subtitle style={styles.subtitle} >
+          {action} Goat Facts
+        </Subtitle>
+      </Button>
+    </View>
+  )
+}
+
+const DrawerContent = ({ styles }) => {
+  return (
+    <View style={styles.main} >
+      <H5 style={{ fontWeight: 'bold' }} >
+        Goat Facts
+      </H5>
+      <P>
+        Goats are herd animals and will become depressed if kept without any goat companions. So, it is unhealthy for a goat if a family just owns one as a pet.
+      </P>
+      <P>
+        Goats’ pupils (like many hooved animals) are rectangular. This gives them vision for 320 to 340 degrees (compared to humans with 160-210) around them without having to move and they are thought to have excellent night vision.
+      </P>
+      <P>
+        Goats, being mountain animals, are very good at climbing; they’ve been known to climb to the tops of trees, or even dams!
+      </P>
+    </View>
+  )
+}
+
+export const Basic = props => {
+  const { initialToggle } = props
+
+  const [ toggled, setToggled ] = useState(initialToggle || false)
+  const drawerStyles = useStylesCallback(buildStyles, [ toggled ], { toggled })
+
+  const onTogglePress = event => {
+    setToggled(!toggled)
+  }
+
+  return (
+    <Grid style={drawerStyles.main} >
+      <Drawer
+        styles={ drawerStyles.drawer }
+        toggled={ toggled }
+      >
+        <DrawerContent styles={ drawerStyles.content } />
+      </Drawer>
+      <DrawerToggle
+        toggled={ toggled }
+        onPress={ onTogglePress }
+        styles={drawerStyles.toggle }
+      />
+    </Grid>
+  )
+
+}
+

--- a/repos/keg-components/src/components/drawer/drawer.examples.js
+++ b/repos/keg-components/src/components/drawer/drawer.examples.js
@@ -127,3 +127,16 @@ export const Basic = props => {
 
 }
 
+// Add the default props here, due to them being defined inline
+// This way we can define default props without effecting the actual component
+Drawer.defaultProps = {
+  type: 'timing',
+  config: {},
+  initial: 0,
+  toggled: false,
+}
+
+// Re-export the Component with the default props defined to be used in the MDX story
+export {
+  Drawer
+}

--- a/repos/keg-components/src/components/drawer/drawer.js
+++ b/repos/keg-components/src/components/drawer/drawer.js
@@ -22,10 +22,13 @@ const noAnimate = (toggled, current, { initial, max }) =>
  * Drawer
  * @param {Object} props - props passed from parent component
  * @param {number} props.initial - Initial height of the slider
- * @param {Function|Component} props.Element - Child Element that goes inside the Drawer
-
- * @param {Object} props.styles - Custom styles to add to the slider
+ * @param {Function|Component} props.children - Child components placed inside the drawer
+ * @param {Function|Component} props.Element - Child Element of the Drawer. Overrides the default children prop
+ * @param {string} props.type - Animation type from the Animated API that accepts an animated config
+ * @param {Object} props.config - Animation config object passed on to the Animated type method
+ * @param {Object} props.styles - Custom styles to applied to the slider
  * @param {boolean} props.toggled - Is the slider toggled open
+ * @param {boolean} props.* - All other props passed on to the Element Component prop if it exists
  *
  * @returns {Component} - Drawer Component
  */
@@ -101,6 +104,7 @@ export const Drawer = props => {
 }
 
 Drawer.propTypes = {
+  className: PropTypes.oneOfType([ PropTypes.array, PropTypes.string ]),
   config: PropTypes.object,
   Element: PropTypes.oneOfType([ PropTypes.func, PropTypes.elementType ]),
   initial: PropTypes.number,

--- a/repos/keg-components/src/components/drawer/drawer.js
+++ b/repos/keg-components/src/components/drawer/drawer.js
@@ -110,5 +110,5 @@ Drawer.propTypes = {
   initial: PropTypes.number,
   styles: PropTypes.oneOfType([ PropTypes.object, PropTypes.array ]),
   toggled: PropTypes.bool,
-  type: PropTypes.string,
+  type: PropTypes.oneOf([ 'decay', 'spring', 'timing' ]),
 }

--- a/repos/keg-components/src/components/drawer/drawer.js
+++ b/repos/keg-components/src/components/drawer/drawer.js
@@ -1,14 +1,8 @@
-/****************** IMPORTANT ******************/ /*
- * This component is a work in progress
- * It's NOT complete or expected to be working
- * It is NOT exported from the main components export
- * It is NOT included in the keg-components bundle
-/****************** IMPORTANT ******************/
-
 import { View } from '../view'
 import PropTypes from 'prop-types'
 import { get } from '@keg-hub/jsutils'
 import { useThemePath } from '../../hooks'
+import { noOpObj } from '../../utils/helpers/noop'
 import { Animated } from 'react-native'
 import { useClassName } from 'KegClassName'
 import React, { useState, useLayoutEffect, useRef } from 'react'
@@ -36,7 +30,7 @@ const noAnimate = (toggled, current, { initial, max }) =>
  * @returns {Component} - Drawer Component
  */
 export const Drawer = props => {
-  const { initial, Element, styles, toggled, className, ...childProps } = props
+  const { initial, Element, styles, toggled, className, type='timing', config=noOpObj, ...childProps } = props
 
   // Define the default heights as a ref
   const heights = useRef({ initial: initial || 0, max: 0 })
@@ -72,10 +66,13 @@ export const Drawer = props => {
     // Update the animation value to animate from
     animation.setValue(heightChanges.from)
     // Start the animation, from value ==> to value
-    Animated.spring(animation, { toValue: heightChanges.to }).start()
+    const animationConfig = config
+      ? { ...config, toValue: heightChanges.to }
+      : { toValue: heightChanges.to }
+    Animated[type](animation, animationConfig).start()
 
     // Add toggled as a dep, so anytime it changes, we run the hook code
-  }, [toggled])
+  }, [toggled, type, config ])
 
   const drawerStyles = useThemePath(`drawer`, styles)
   const classRef = useClassName('keg-drawer', className)
@@ -104,8 +101,10 @@ export const Drawer = props => {
 }
 
 Drawer.propTypes = {
-  initial: PropTypes.number,
+  config: PropTypes.object,
   Element: PropTypes.oneOfType([ PropTypes.func, PropTypes.elementType ]),
+  initial: PropTypes.number,
   styles: PropTypes.oneOfType([ PropTypes.object, PropTypes.array ]),
   toggled: PropTypes.bool,
+  type: PropTypes.string,
 }

--- a/repos/keg-components/src/components/drawer/drawer.stories.mdx
+++ b/repos/keg-components/src/components/drawer/drawer.stories.mdx
@@ -1,0 +1,26 @@
+<!--- Drawer.stories.mdx -->
+
+import { Story, Meta, Preview, Props, Description } from '@storybook/addon-docs/blocks'
+
+import { Basic } from './drawer.examples'
+import { Drawer } from './drawer'
+
+<Meta title="Interactions/Drawer" component={Drawer}/>
+
+# Drawer
+
+Base component for slide toggling the display of child content
+
+
+### Basic Example
+
+<Preview>
+  <Story name="Basic">
+    <Basic />
+  </Story>
+</Preview>
+
+
+### Props
+
+<Props of={Drawer} />

--- a/repos/keg-components/src/components/drawer/drawer.stories.mdx
+++ b/repos/keg-components/src/components/drawer/drawer.stories.mdx
@@ -12,7 +12,7 @@ import { Drawer } from './drawer'
 Base component for slide toggling the display of child content
 
 
-### Basic Example
+### Example
 
 <Preview>
   <Story name="Basic">

--- a/repos/keg-components/src/components/form/input/input.js
+++ b/repos/keg-components/src/components/form/input/input.js
@@ -71,6 +71,7 @@ export const Input = React.forwardRef((props, ref) => {
       {...usePressHandlers(false, { onClick, onPress })}
       {...elProps}
       style={[ inputStyles, style ]}
+      ref={ref}
     />
   )
 })

--- a/repos/keg-components/src/components/typography/p.js
+++ b/repos/keg-components/src/components/typography/p.js
@@ -1,2 +1,12 @@
+import React from 'react'
 import { KegText } from 'KegText'
-export const P = KegText('paragraph')
+const Paragraph = KegText('paragraph')
+
+export const P = props => {
+  return (
+    <>
+      <Paragraph {...props} />
+      {'\n'}
+    </>
+  )
+}

--- a/repos/keg-components/src/hooks/useClassList.js
+++ b/repos/keg-components/src/hooks/useClassList.js
@@ -19,5 +19,5 @@ export const useClassList = (className, classList = noPropArr) => {
   const classListArr = eitherArr(classList, [classList])
   return useMemo(() => {
     return ensureClassArray(classListArr).concat([className])
-  }, [ className, ...classListArr ])
+  }, [ className, classListArr.join(' ') ])
 }

--- a/repos/keg-components/src/theme/typography.js
+++ b/repos/keg-components/src/theme/typography.js
@@ -52,6 +52,7 @@ export const typography = {
   },
   h5: {
     fontSize: 20,
+    marginBottom: margin.size,
     ...compFontDefs.h5,
   },
   h6: {
@@ -72,6 +73,8 @@ export const typography = {
   paragraph: {
     fontSize: fontDefs.size || 16,
     letterSpacing: 0.5,
+    marginBottom: margin.size,
+    lineHeight: 20,
     ...compFontDefs.paragraph,
   },
   subtitle: {

--- a/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
@@ -1,6 +1,3 @@
-jest.resetModules()
-jest.resetAllMocks()
-
 const { hyphenator, hashString, getSelector, addStylesToDom } = require('../injectHelpers')
 import * as themeEvents from '../../theme/themeEvent'
 

--- a/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
@@ -1,4 +1,3 @@
-const { hyphenator, hashString, getSelector, addStylesToDom } = require('../injectHelpers')
 import * as themeEvents from '../../theme/themeEvent'
 
 jest.resetModules()

--- a/repos/re-theme/src/styleInjector/__tests__/styleInjector.js
+++ b/repos/re-theme/src/styleInjector/__tests__/styleInjector.js
@@ -1,0 +1,85 @@
+import React from 'react'
+
+jest.resetModules()
+jest.resetAllMocks()
+
+const mockUseStyleTag = jest.fn(() => {
+  return { classList: ['test-mock-component'], filteredStyle: {} }
+})
+
+jest.setMock('../useStyleTag', { useStyleTag: mockUseStyleTag })
+
+const mockConfig = { displayName: 'MockComponent', className: 'test-mock-component' }
+const mockProps = { style: { color: `#111111` } }
+
+const MockComponent = props => {
+  return React.createElement('div', props, 'I am a div')
+}
+
+const { StyleInjector } = require('../styleInjector')
+
+describe('styleInjector', () => {
+
+  afterEach(() => {
+    mockUseStyleTag.mockClear()
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return the original component when a style prop does not exists', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    const mockComp = WrappedComp.render({})
+
+    expect(mockComp.type).toBe(MockComponent)
+  })
+
+  it('should return the BuildWithStyles component NOT the original when style prop exists', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    expect(WrappedComp[`$$typeof`].toString()).toBe(`Symbol(react.forward_ref)`)
+    expect(typeof WrappedComp.render).toBe('function')
+    const mockComp = WrappedComp.render(mockProps)
+    
+    expect(mockComp).not.toBe(MockComponent)
+  })
+
+  test('Returned component should call useStyleTag when rendered', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    const mockComp = WrappedComp.render(mockProps)
+    mockComp.type.render(mockComp.props)
+    
+    expect(mockUseStyleTag).toHaveBeenCalled()
+  })
+
+  test('Returned component pass the style, className and config to the useStyleTag hook', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    const mockComp = WrappedComp.render(mockProps)
+    mockComp.type.render(mockComp.props) 
+    const argsArr = mockUseStyleTag.mock.calls[0]
+
+    expect(argsArr[0]).toBe(mockProps.style)
+    expect(argsArr[1]).toBe(mockConfig.className)
+    expect(argsArr[2]).toBe(mockConfig)
+  })
+
+  test('should return the original component with the className, but without the original styles', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    const mockComp = WrappedComp.render(mockProps)
+    const OrgComponent = mockComp.type.render(mockComp.props) 
+
+    expect(OrgComponent.type).toBe(MockComponent)
+    expect(OrgComponent.props.style).not.toBe(mockProps.style)
+    expect(OrgComponent.props.className[0]).toBe(mockConfig.className)
+  })
+
+  test('should pass all other props onto the original component', () => {
+    const WrappedComp = StyleInjector(MockComponent, mockConfig)
+    const mockComp = WrappedComp.render(mockProps)
+    const OrgComponent = mockComp.type.render({ ...mockComp.props, other: 'prop', custom: 'test-prop' }) 
+
+    expect(OrgComponent.props.other).toBe('prop')
+    expect(OrgComponent.props.custom).toBe('test-prop')
+  })
+
+})


### PR DESCRIPTION
## Context

* We need a drawer component

## Goal

* Add a drawer component

## Updates

* `repos/keg-components/src/components/box/textBox.stories.js`
  * Fixed bug causing the input ref to not be set properly
* `repos/keg-components/src/components/drawer/drawer.examples.js`
  * Added example of using the drawer component
* `repos/keg-components/src/components/drawer/drawer.js`
  * Finished the drawer component
* `repos/keg-components/src/components/drawer/drawer.stories.mdx`
  * Added a story to show a working example of using the drawer component
* `repos/keg-components/src/components/form/input/input.js`
  * Added the passed in ref to the Input component props
* `repos/keg-components/src/components/typography/p.js`
  * Updated the paragraph component to have consistent behavior with web
  * Each new paragraph should be on it's own line
* `repos/keg-components/src/hooks/useClassList.js`
  * Fixed a bug that causes an error to throw in some cases when using the hook
* `repos/keg-components/src/theme/typography.js`
  * Updated the paragraph component to have consistent behavior with web
  * Each new paragraph should be on it's own line
* `repos/re-theme/src/styleInjector/__tests__/injectHelpers.js` && `repos/re-theme/src/styleInjector/__tests__/styleInjector.js`
  * Added more tests


## Testing

* Run the docker package => `keg dpg run docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:keg-drawer-component`
  * Ensure the textbox component does not throw an error when [typing into the input]((http://snpy.in/F0KV1f))
  * Ensure the drawer component [stories render properly](http://snpy.in/BHW7vz)
  * Ensure you can [open and close the drawer](http://snpy.in/enTSTD)
* Pull the PR, and run tests for ReTheme
  * `keg retheme && keg pr 41 && yarn install && yarn test`
  * Ensure all tests pass
