### PR TITLE
Keg-CLI - sync option for injected apps

### DIFF
--- a/repos/keg-cli/src/utils/services/composeService.js
+++ b/repos/keg-cli/src/utils/services/composeService.js
@@ -7,6 +7,7 @@ const { runInternalTask } = require('../task/runInternalTask')
 const { buildExecParams } = require('../docker/buildExecParams')
 const { getContainerCmd } = require('../docker/getContainerCmd')
 const { KEG_DOCKER_EXEC, KEG_EXEC_OPTS } = require('KegConst/constants')
+
 /**
  * Runs `docker-compose` up command based on the passed in args
  * @function
@@ -16,7 +17,7 @@ const { KEG_DOCKER_EXEC, KEG_EXEC_OPTS } = require('KegConst/constants')
  * @returns {Array} - An array of promises for each sync being setup
  */
 const createSyncs = async (args, containerContext) => {
-  const { params: { sync, tap, context } } = args
+  const { params: { sync, tap, context, __injected } } = args
   const { cmdContext, container, id } = containerContext
   const dockerContainer = container || id || cmdContext || context
 
@@ -25,7 +26,7 @@ const createSyncs = async (args, containerContext) => {
       const resolved = await toResolve
       resolved.push(
         await syncService(
-          { ...args, params: { dependency, tap, context } },
+          { ...args, params: { dependency, tap, context, __injected } },
           { container: dockerContainer, dependency }
         )
       )


### PR DESCRIPTION
## Context
* The `--sync` option does not work when starting injected apps

## Updates
* `repos/keg-cli/src/utils/services/composeService.js`
  * The injected params were not being passed to the sync service
  * Which is why it could not find the `docker-compose.yml` file
  * For **non**-injected apps keg-cli knows the location is the containers folder
  * But for __injected apps, that info is stored on `params.__injected`.
  * By passing along the `__injected` argument, the `docker-compose.yml` file can be found

## Test
**Setup**
* Ensure the `events-force` tap is linked to the keg-cli
* Download the [keg-test-consumer](https://github.com/simpleviewinc/keg-test-consumer)
* Navigate to the directory where you downloaded the repo
* Ensure the repo is is linked as a tap with `keg tap link consumer`

**Test**
* Run the start command, with the `--sync` option
  * `keg consumer start --sync evf:install`
    * **Important** If an error is throw durring the start command. Make sure it's an error with they sync process and not the app it's self.
      * This PR is only about fixing the `--sync` option
    * Ensure it runs the install command for the events force tap before starting the consumer tap
  * Ensure it creates a sync
    * Open a new tap in your terminal, and run `keg sy`
    * You should see a sync for `consumer-evf`
