### PR TITLE
Updates

### DIFF
--- a/repos/re-theme/src/styleParser/cssToJs.js
+++ b/repos/re-theme/src/styleParser/cssToJs.js
@@ -1,5 +1,6 @@
 import { exists, camelCase, isArr } from '@keg-hub/jsutils'
 
+
 /**
  * Matches all content between `{}`
  * @example
@@ -7,11 +8,20 @@ import { exists, camelCase, isArr } from '@keg-hub/jsutils'
  * @function
  * @param {string} styleStr - Css styles in string format
  * 
- * @returns {string} - Content inbetween the {} of the passed in string
+ * @returns {string} - Content between the {} of the passed in string
  */
 const getStyleContent = styleStr => {
-  const matches = [ ...styleStr.matchAll(/\{(.+?)\}/gi) ]
-  return isArr(matches) && isArr(matches[0]) ? matches[0][1] : ''
+  const pattern = /\{(.+?)\}/
+  const regex = new RegExp(pattern, 'gi')
+  const matches = []
+  const foundMatch = styleStr.match(regex)
+
+  for (let index in foundMatch){
+    const item = foundMatch[index]
+    matches[index] = item.match(new RegExp(pattern)) 
+  }
+
+  return isArr(matches[0]) ? matches[0][1] : ''
 }
 
 /**


### PR DESCRIPTION
  * Added a custom matchAll helper for find the style content

**Ticket**: [ZEN-388](https://jira.simpleviewtools.com/browse/ZEN-388)

## Context

* The String prototype method does not work in all browsers. This caused the app to fail in those cases

## Goal

* Ensure the app works in the browsers we support

## Updates

* `repos/re-theme/src/styleParser/cssToJs.js`
  * Replace the use of `str.matchAll` with a custom match method

## Testing
* Run the docker package URL
  *`keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-388-fix-matchall`
  * ensure  the app works as expected
* Pull the branch and run the tests
  * `keg retheme && keg pr 43 && yarn install && yarn test`
