### PR TITLE
added the other noOp obj

### DIFF
--- a/repos/keg-core/core/base/utils/helpers/method/noop.js
+++ b/repos/keg-core/core/base/utils/helpers/method/noop.js
@@ -1,6 +1,13 @@
+import { deepFreeze } from '@keg-hub/jsutils'
 /**
  * @summary Empty function that does nothing
  *
  * @returns {function}
  */
-export const noOp = () => {}
+export const noOp = Object.freeze(() => {})
+
+export const noOpObj = Object.freeze({})
+
+export const noPropObj = deepFreeze({ content: {} })
+
+export const noPropArr = deepFreeze([])

--- a/repos/keg-core/core/base/utils/helpers/method/noop.js
+++ b/repos/keg-core/core/base/utils/helpers/method/noop.js
@@ -8,6 +8,4 @@ export const noOp = Object.freeze(() => {})
 
 export const noOpObj = Object.freeze({})
 
-export const noPropObj = deepFreeze({ content: {} })
-
 export const noPropArr = deepFreeze([])

--- a/repos/keg-core/core/base/utils/helpers/method/noop.js
+++ b/repos/keg-core/core/base/utils/helpers/method/noop.js
@@ -6,6 +6,16 @@ import { deepFreeze } from '@keg-hub/jsutils'
  */
 export const noOp = Object.freeze(() => {})
 
+/**
+ * @summary Frozen empty object
+ *
+ * @returns {object}
+ */
 export const noOpObj = Object.freeze({})
 
+/**
+ * @summary frozen empty array
+ *
+ * @returns {Array}
+ */
 export const noPropArr = deepFreeze([])


### PR DESCRIPTION
**Ticket**: n/a

## Context

* adding more noOp items in keg-core for the Tap to use

## Goal

* adding more noOp items in keg-core for the Tap to use so I can use the `noPropArr` in the tap

## Updates

* `repos/keg-core/core/base/utils/helpers/method/noop.js`
   * added noOpObj, noPropObj, noPropArr

## Testing
* n/a
