### PR TITLE
Parsing cssRules safely

### DIFF
--- a/repos/re-theme/src/styleParser/__tests__/getCSSRules.js
+++ b/repos/re-theme/src/styleParser/__tests__/getCSSRules.js
@@ -1,0 +1,56 @@
+import { getCSSRules } from '../getCSSRules'
+
+const mockValidSheet = {
+  cssRules: [ 1, 2, 3 ]
+}
+
+const mockRestrictedSheet = {
+  get cssRules () {
+    throw new DOMException('DOMException Message', 'SecurityError')
+  }
+}
+
+const mockExceptionSheet = {
+  get cssRules () {
+    throw new Error('GenericError')
+  }
+}
+
+describe('getCSSRules', () => {
+  const orig = console.warn
+
+  beforeEach(() => {
+    console.warn = jest.fn()
+  })
+
+  afterAll(() => {
+    console.warn = orig
+  })
+
+  it('should return an empty array if the stylesheet is falsy', () => {
+    const results = [ null, false, undefined, '', 0 ].map(getCSSRules)
+    results.map(result => expect(result).toEqual([]))
+    expect(console.warn).not.toBeCalled()
+  })
+
+  it('should simply cssRules for stylesheet without CORS', () => {
+    const result = getCSSRules(mockValidSheet)
+    expect(result).toEqual(mockValidSheet.cssRules)
+    expect(console.warn).not.toBeCalled()
+  })
+
+  it ('should log warnings for restricted sheets', () => {
+    const result = getCSSRules(mockRestrictedSheet)
+    expect(result).toEqual([])
+    const warningText = console.warn.mock.calls[0][0]
+    expect(warningText).toEqual(expect.stringContaining('cross-origin'))
+  })
+
+  it ('should log warnings for other errors', () => {
+    const result = getCSSRules(mockExceptionSheet)
+    expect(result).toEqual([])
+    const warningText = console.warn.mock.calls[0][2]
+    expect(warningText).toEqual(expect.stringContaining('Reason: '))
+  })
+
+})

--- a/repos/re-theme/src/styleParser/getCSSRules.js
+++ b/repos/re-theme/src/styleParser/getCSSRules.js
@@ -1,0 +1,53 @@
+/**
+ * Helper for warnOfError
+ * @param {*} error 
+ * @returns {boolean} true if the input is a DOMException Security Error
+ */
+const isSecurityError = error => {
+  return error instanceof DOMException
+    && error.name?.includes('SecurityError')
+}
+
+/**
+ * Helper for getCSSRules - handles the error arising from getting 
+ * stylesheet cssRules property
+ * @param {*} stylesheet 
+ * @param {Error} error 
+ */
+const warnOfStylesheetError = (stylesheet, error) => {
+  if (isSecurityError(error)) {
+    console.warn(
+      'Cannot parse cross-origin restricted stylesheet from source:',
+      stylesheet.href,
+      '\nThis stylesheet will be safely ignored, but if you need access to it, then you should either ensure the domains match or adjust the stylesheet server\'s security policy.'
+    )
+  }
+  else {
+    console.warn(
+      'Cannot parse stylesheet from source:',
+      stylesheet.href,
+      `\n Reason: ${error.name} - ${error.message}`, 
+    )
+  }
+}
+
+/**
+ * Safely returns the css rules from the stylesheet object,
+ * handling any errors that might arise from that and 
+ * logging them to the console. If an error arose,
+ * or if the stylesheet is falsy, this returns an empty array
+ * @param {*} stylesheet 
+ * @return {Array<CSSStyleRule>}
+ */
+export const getCSSRules = stylesheet => {
+  try {
+    return stylesheet
+      ? stylesheet.cssRules
+      : []
+  }
+  catch (e) {
+    warnOfStylesheetError(stylesheet, e)
+  }
+
+  return []
+}

--- a/repos/re-theme/src/styleParser/getCSSRules.js
+++ b/repos/re-theme/src/styleParser/getCSSRules.js
@@ -11,21 +11,21 @@ const isSecurityError = error => {
 /**
  * Helper for getCSSRules - handles the error arising from getting 
  * stylesheet cssRules property
- * @param {*} stylesheet 
+ * @param {Object} stylesheet 
  * @param {Error} error 
  */
 const warnOfStylesheetError = (stylesheet, error) => {
   if (isSecurityError(error)) {
     console.warn(
       'Cannot parse cross-origin restricted stylesheet from source:',
-      stylesheet.href,
+      stylesheet?.href,
       '\nThis stylesheet will be safely ignored, but if you need access to it, then you should either ensure the domains match or adjust the stylesheet server\'s security policy.'
     )
   }
   else {
     console.warn(
       'Cannot parse stylesheet from source:',
-      stylesheet.href,
+      stylesheet?.href,
       `\n Reason: ${error.name} - ${error.message}`, 
     )
   }

--- a/repos/re-theme/src/styleParser/styleSheetParser.js
+++ b/repos/re-theme/src/styleParser/styleSheetParser.js
@@ -1,4 +1,5 @@
 import { isArr, checkCall, isObj } from '@keg-hub/jsutils'
+import { getCSSRules } from './getCSSRules'
 import { validateArguments } from './validate'
 import { addToDom } from './addToDom'
 import { cssToJs } from './cssToJs'
@@ -14,8 +15,10 @@ import { cssToJs } from './cssToJs'
  * @returns {Object|string} - CssInJs object or string of the converted styles
  */
 const loopSheetCssRules = (formatted, sheet, classNames, callback) => {
+  const rules = getCSSRules(sheet)
+
   // Check the rules of each styleSheet for a matching class
-  return Array.from(sheet.cssRules)
+  return Array.from(rules)
     .reduce((formatted, cssRule) => {
 
       if (!cssRule.selectorText || !cssRule.cssText) return formatted


### PR DESCRIPTION
## Context

* The consumer of a tap may have external stylesheets with security policies restricting access to the css rules
* these can throw errors when our style parser attempts to access the `stylesheet.cssRules` property, crashing the app

## Goal

* Wrap that code in a `try-catch`, logging some useful warnings if the security error is thrown, and preventing the app from crashing

## Updates

* `repos/re-theme/src/styleParser/getCSSRules.js`
  * wrote the helper for accessing the rules safely
  * also wrote tests in the associated test file
* `repos/re-theme/src/styleParser/styleSheetParser.js`
  * updated the `styleSheetParser` to use `getCSSRules`

## Testing

* `keg consumer pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/keg-test-consumer:master`
  * this will load `keg-test-consumer` with a version of the tap that has these changes.
  * the version of `keg-test-consumer` will also have an external stylesheet I added in that usually would throw a CORS error when the `styleSheetParser` runs
* verify that the app does not crash on init
* verify that it looks as expected
* verify it logs a warning like this: 

```
Cannot parse cross-origin restricted stylesheet from source: https://s.yimg.com/kw/engadget/mod/css/app.97d3be22f549f3ee735498c6ad908c19.css 
This stylesheet will be safely ignored, but if you need access to it, then you should either ensure the domains match or adjust the stylesheet server's security policy. keg-sessions.esm.js:1
```

* `keg pr 54 && keg retheme`
* `yarn test`
* verify all tests pass
