### PR TITLE
Keg Dependency Mismatch

### DIFF
--- a/repos/keg-cli/package.json
+++ b/repos/keg-cli/package.json
@@ -42,10 +42,11 @@
     "js-yaml": "3.14.0",
     "log-update": "4.0.0",
     "module-alias": "2.2.2",
-    "rimraf": "2.6.3",
-    "write-yaml-file": "4.0.0",
     "ngrok": "3.2.7",
-    "qrcode-terminal": "0.12.0"
+    "qrcode-terminal": "0.12.0",
+    "rimraf": "2.6.3",
+    "semver": "^7.3.2",
+    "write-yaml-file": "4.0.0"
   },
   "devDependencies": {
     "jest": "24.8.0",

--- a/repos/keg-cli/src/tasks/hub/dependencies.js
+++ b/repos/keg-cli/src/tasks/hub/dependencies.js
@@ -1,0 +1,210 @@
+const semver = require('semver')
+const { Logger } = require('KegLog')
+const { getHubRepos } = require('KegUtils/hub/getHubRepos')
+const { reduceObj, mapObj, get, set } = require('@keg-hub/jsutils')
+
+/**
+ * Loops over a repos dependencies and compares it with all other repo dependencies
+ * @param {string} repo - Name of the current repo to build the map for
+ * @param {Object} allDependencies - All dependencies from the keg-hub repos
+ * @param {Object} dependencies - Dependencies of the current repo
+ * @param {string} type - Type of dependencies from the package.json of the current repo
+ *
+ * @returns {Object} - Mapped dependencies version mismatches
+ */
+const loopDependency = (repo, allDependencies, dependencies, type) => {
+  return reduceObj(dependencies, (dependency, version, updated) => {
+    !updated.cache[dependency]
+      ? (updated.cache[dependency] = { [repo]: { version, type } })
+      : (updated.versions[dependency] = {
+          ...updated.cache[dependency],
+          ...updated.versions[dependency],
+          [repo]: { version, type }
+        })
+
+    return updated
+  }, allDependencies)
+}
+
+/**
+ * Builds a dependency map of all repos dependencies
+ * @param {Object} allDependencies - All dependencies from the keg-hub repos
+ * @param {Object} package - The package.json of the current repo
+ * @param {string} repo - Name of the current repo to build the map for
+ *
+ * @returns {Object} - Mapped dependencies version mismatches
+ */
+const buildDepMap = (allDependencies, package, repo) => {
+  const { dependencies, devDependencies, peerDependencies } = package
+  let mappedDependencies = loopDependency(
+    repo,
+    allDependencies,
+    devDependencies,
+    'devDependencies',
+  )
+
+  mappedDependencies = loopDependency(
+    repo,
+    mappedDependencies,
+    dependencies,
+    'dependencies'
+  )
+
+  return loopDependency(
+    repo,
+    mappedDependencies,
+    peerDependencies,
+    'peerDependencies'
+  )
+}
+
+/**
+ * Loops over all versions of dependencies and finds the differences
+ * @param {Object} versions - All dependencies and their versions
+ *
+ * @returns {Object} - Mapped dependencies version mismatches
+ */
+const diffDepVersions = versions => {
+  return reduceObj(versions, (depName, mapped, mismatch) => {
+    mapObj(mapped, (repo, meta) => {
+      mapObj(mapped, (altRepo, altMeta) => {
+        if(altRepo === repo) return
+        
+        try {
+
+          semver.neq(
+            semver.coerce(meta.version),
+            semver.coerce(altMeta.version)
+          ) && ( mismatch[depName] = {
+            ...mismatch[depName],
+            [repo]: meta,
+            [altRepo]: altMeta,
+          })
+
+        }
+        catch(err){
+          console.log(
+            `\n`,
+            `Error - ${err.message}\n`,
+            `Dependency - ${depName}\n`,
+            `Repo - ${repo} | Version - ${meta.version}\n`,
+            `Other Repo - ${altRepo} | Other Version - ${altMeta.version}\n`,
+          )
+        }
+      })
+    })
+
+    return mismatch
+  })
+}
+
+/**
+ * Formats all dependencies mismatches to be printed
+ * @param {Object} mismatched - All mismatched repos
+ *
+ * @returns {Object} - Dependencies to be rendered
+ */
+const formatMismatches = mismatched => {
+  return reduceObj(mismatched, (depName, mapped, toRender) => {
+    mapObj(mapped, (repo, meta) => {
+      toRender[depName] = toRender[depName] || {}
+      toRender[depName][meta.version] = toRender[depName][meta.version] || []
+      toRender[depName][meta.version].push(repo)
+    })
+
+    return toRender
+  })
+}
+
+/**
+ * Prints out the found mismatches dependencies of the keg-hub repos
+ * @param {Object} formatted - Dependencies, repos and versions
+ *
+ * @returns {void}
+ */
+const displayMismatches = formatted => {
+  Logger.header(`Mismatched Dependencies`)
+
+  mapObj(formatted, (depName, mapped) => {
+    Logger.pair(`  Dependency:`, depName)
+
+    mapObj(mapped, (version, repos) => {
+      Logger.pair(`    ${version}:`, repos.join(', '))
+    })
+
+    Logger.empty()
+  })
+}
+
+/**
+ * Compares the package.json dependencies
+ * <br/>Finds all dependencies that are mismatched and prints out their versions
+ * @param {Object} repos - Meta data for all repos of the keg-hub
+ *
+ * @returns {void}
+ */
+const compareVersions = repos => {
+  const allDependencies = { cache: {}, versions: {} }
+  repos.map(({ repo, package }) => buildDepMap(allDependencies, package, repo))
+  const mismatched = diffDepVersions(allDependencies.versions)
+  const formatted = formatMismatches(mismatched)
+
+  displayMismatches(formatted)
+}
+
+const updateVersion = (repos, update) => {
+  // TODO: Add code from other branch to update the versions
+}
+
+/**
+ * Get information about the keg-hub repos information
+ * @param {Object} args - arguments passed from the runTask method
+ * @param {string} args.command - Initial command being run
+ * @param {Array} args.options - arguments passed from the command line
+ * @param {Object} args.tasks - All registered tasks of the CLI
+ * @param {Object} globalConfig - Global config object for the keg-cli
+ *
+ * @returns {void}
+ */
+const hubDeps = async args => {
+  const { params } = args
+  const { update } = params
+  const repos = []
+
+  await getHubRepos({ ...params, callback: (repo, package, { location }) => {
+    repos.push({
+      repo,
+      package,
+      location,
+    })
+  }})
+
+  compareVersions(repos)
+  update && updateVersion(repos)
+
+  return repos
+}
+
+module.exports = {
+  dependencies: {
+    name: 'dependencies',
+    alias: [ 'deps', 'dep', 'dp'],
+    action: hubDeps,
+    description: `Gets information about keg-hub repos dependencies`,
+    example: 'keg hub dependencies <options>',
+    options: {
+      context: {
+        alias: [ 'ctx', 'filter', 'ftr', 'scope', 'scp' ],
+        description: 'Filter results based on a repo(s) name',
+        example: 'keg hub dependencies --scope cli',
+        default: 'all'
+      },
+      update: {
+        alias: [ 'up' ],
+        description: 'Updates a specific dependency in all repos where it exists',
+        example: 'keg hub dependencies --update <dependency>:<version>',
+        default: true
+      }
+    }
+  }
+}

--- a/repos/keg-cli/src/tasks/hub/hub.js
+++ b/repos/keg-cli/src/tasks/hub/hub.js
@@ -4,6 +4,7 @@ module.exports = {
     description: 'Keg Hub mono-repo tasks',
     example: 'keg hub <command> <options>',
     tasks: {
+      ...require('./dependencies'),
       ...require('./repos'),
       ...require('./run'),
     }

--- a/repos/keg-cli/yarn.lock
+++ b/repos/keg-cli/yarn.lock
@@ -4310,6 +4310,11 @@ semver@^6.0.0, semver@^6.2.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"


### PR DESCRIPTION
## Context

* We need to keep the dependencies consistent across the repos in keg-hub

## Goal

* Added task to compare package.json dependencies across repos
  * This just prints out a nice list of dependency version mismatch for all keg-hub repos
  * There's [another branch that has the code to update and save the dependencies](https://github.com/simpleviewinc/keg-hub/pull/53)

## Updates
* `repos/keg-cli/package.json`
  * Added semver package
* `repos/keg-cli/src/tasks/hub/dependencies.js`
  * Added task to load all package.json and find dependency mismatches
* `repos/keg-cli/src/tasks/hub/hub.js`
  * Added dependencies task


## Testing
* Pull this branch => `keg pr 57`
* Install the dependency updates for keg-cli
  * `keg cli && yarn install`
* Run the command => `keg hub dep`
  * Ensure it prints out a list of mismatched dependencies for the keg-hub repos