### PR TITLE
Fix Safari Crashing

### DIFF
--- a/repos/re-theme/src/styleParser/getCSSRules.js
+++ b/repos/re-theme/src/styleParser/getCSSRules.js
@@ -41,9 +41,7 @@ const warnOfStylesheetError = (stylesheet, error) => {
  */
 export const getCSSRules = stylesheet => {
   try {
-    return stylesheet
-      ? stylesheet.cssRules
-      : []
+    return stylesheet?.cssRules || []
   }
   catch (e) {
     warnOfStylesheetError(stylesheet, e)


### PR DESCRIPTION
## Context

* currently, our build is crashing on safari.
* see for yourself here: https://simpleviewinc.github.io/keg-test-consumer/
* the error complains about `Array.from` being called with a nullish argument
* the reason this is happening is because safari does NOT throw an error when trying to access a CORS-restricted stylesheet's `.cssRules` property (like the other browsers do). Instead, it apparently just returns null.


## Goal

* fix this error

## Updates

* `repos/re-theme/src/styleParser/getCSSRules.js`
  * ensures `getCSSRules` always returns an array, never null

## Testing

* `keg consumer pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/keg-test-consumer:master`
* in safari, open `local.kegdev.xyz`
* verify the app does not crash
