### PR TITLE
Zen 431 keg prefix filter

### DIFF
--- a/repos/keg-components/src/theme/components/textToggle.js
+++ b/repos/keg-components/src/theme/components/textToggle.js
@@ -23,7 +23,9 @@ export const textToggle = {
     main: {
       mV: 15,
       alI: 'flex-end',
-      txDc: 'underline',
+    },
+    text: {
+      txDL: 'underline',
     },
   },
 }

--- a/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
@@ -119,6 +119,28 @@ describe('injectHelpers', () => {
       expect(getSelector(undefined, `my-test-styles`)).toBe(`.keg-275181350`)
     })
 
+    it('should filter out classnames without prefix `keg`', () => {
+
+      // check if string includes all of the values in the array
+      const includes = (str, values) => {
+        return values.reduce((accumulator, value) => 
+          accumulator && str.includes(value)
+        , true)
+      }
+      // array classnames
+      const selector = getSelector([`test-class`, `test-keg-2`, `keg-text`], `my-test-styles`, 'keg')
+      const includeTestClass = includes(selector, [`test-class`, `test-keg-2`])
+      expect(includeTestClass).toBe(false)
+      expect(selector.includes('keg-text')).toBe(true)
+
+      // string classnames
+      const selector2 = getSelector(`keg-text test-class test-class-2`, `my-test-styles`, 'keg')
+      const includeTestClass2 = includes(selector2, [`test-class`, `test-class-2`])
+      expect(includeTestClass2).toBe(false)
+      expect(selector.includes('keg-text')).toBe(true)
+
+    })
+
   })
 
   describe('clearStyleSheet', () => {

--- a/repos/re-theme/src/styleInjector/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/injectHelpers.js
@@ -132,7 +132,7 @@ export const getSelector = (className, cssString, filterPrefix) => {
 
   // filter by prefix if passed in
   const filterWithPrefix = cls => {
-    return filterPrefix
+    return cls && filterPrefix
       ? cls.startsWith(filterPrefix)
       : cls
   }

--- a/repos/re-theme/src/styleInjector/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/injectHelpers.js
@@ -122,17 +122,27 @@ export const filterRules = (style, filter) => {
 /**
  * Creates a unique selector based on the passed in className and cssString
  * @function
- * @param {string} className - Original className used as a css selector
+ * @param {string|Array<string>} className - Original className(s) used as a css selector
  * @param {string} cssString - Css rules for the className in string format
- *
+ * @param {string=} filterPrefix - optional prefix to filter by
+ * 
  * @returns {string} - Hashed version of the string
  */
-export const getSelector = (className, cssString) => {
+export const getSelector = (className, cssString, filterPrefix) => {
+
+  // filter by prefix if passed in
+  const filterWithPrefix = cls => {
+    return filterPrefix
+      ? cls.startsWith(filterPrefix)
+      : cls
+  }
+
   const selector = !exists(className)
     ? false
     : isArr(className)
-      ? className.filter(cls => cls).join('.').trim()
-      : isStr(className) && className.split(' ').join('.').trim()
+      ? className.filter(filterWithPrefix).join('.').trim()
+      : isStr(className) && className.split(' ').filter(filterWithPrefix).join('.').trim()
+
 
   return selector
     ? `.${selector}.keg-${hashString(cssString)}`.trim()

--- a/repos/re-theme/src/styleInjector/useStyleTag.js
+++ b/repos/re-theme/src/styleInjector/useStyleTag.js
@@ -77,9 +77,9 @@ export const convertToCss = (style, config) => {
  * <br/>After converting it, it appends it to the Dom
  * <br/>It also keeps a hash of all appended styles rules to avoid duplication
  * @param {Object} style - Styles rules to be converted and added to the Dom
- * @param {string|Array[string]} className - Css selector of the style fules
+ * @param {string|Array<string>} className - Css selector(s) of the style fules
  * 
- * @returns {string} - className Css selector of the added style rules
+ * @returns {Object} - className Css selector of the added style rules
  */
 export const useStyleTag = (style, className='', config) => {
   // Ensure config is an object
@@ -93,7 +93,7 @@ export const useStyleTag = (style, className='', config) => {
     const { blocks, filtered } = convertToCss(style, config)
 
     // Create a unique selector based on the className and built blocks
-    const selector = getSelector(className, blocks.join(''))
+    const selector = getSelector(className, blocks.join(''), 'keg')
 
     // Adds the css selector ( className ) to each block
     const css = blocks.reduce((css, block) => {


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-431)

`[semver]: patch`

## Context

* Currently the useStyleTag hook uses all classes of a component to create a css selector
* This works exactly as it should, but creates very specific selectors
* This makes it hard to override the styles from outside re-theme
* Update the getSelector used in the useStyleTag hook to only use classes with the keg prefix
    * All non-keg prefixed classes should be filtered out

## Goal

* update retheme getSelector to be able to filter out by prefix tag if passed in
* also minor style update to `textToggle` its showing 2 underlines in some FireFox browsers

## Updates

* `repos/keg-components/src/theme/components/textToggle.js`
   * the underline style is supposed to only be on the text component, not the container component

* `repos/re-theme/src/styleInjector/__tests__/injectHelpers.js`
   * expanded the `getSelector` tests

* `repos/re-theme/src/styleInjector/injectHelpers.js`
   * added a third optional param to filter by prefix



## Testing

* run `keg dpg run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:develop`
* verify that all the elements only have `keg-` classnames
* there should be no `ef` or `evf` classnames

### Unit Test
* pull the branch down locally
* run `keg retheme && yarn test`
* ensure all test passes
