### PR TITLE
update keg prefix to still apply the classname to component

### DIFF
--- a/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/__tests__/injectHelpers.js
@@ -99,24 +99,24 @@ describe('injectHelpers', () => {
     })
 
     it('should return a css className selector with a has the passed in className', () => {
-      const selector = getSelector(`test-class`, `my-test-styles`)
+      const {selector} = getSelector(`test-class`, `my-test-styles`)
       expect(selector.includes(`test-class`)).toBe(true)
     })
 
     it('should should add a . to the passed in className', () => {
-      const selector = getSelector(`test-class`, `my-test-styles`)
+      const {selector} = getSelector(`test-class`, `my-test-styles`)
       expect(selector.includes(`.test-class`)).toBe(true)
     })
 
     it('should should accept className as an array', () => {
-      const selector = getSelector([`test-class`, `test-class-2`], `my-test-styles`)
+      const {selector} = getSelector([`test-class`, `test-class-2`], `my-test-styles`)
       expect(selector.includes(`.test-class`)).toBe(true)
       expect(selector.includes(`.test-class-2`)).toBe(true)
     })
 
     it('should not fail when no className is passed in', () => {
-      const selector = getSelector(undefined, `my-test-styles`)
-      expect(getSelector(undefined, `my-test-styles`)).toBe(`.keg-275181350`)
+      const {selector} = getSelector(undefined, `my-test-styles`)
+      expect(selector).toBe(`.keg-275181350`)
     })
 
     it('should filter out classnames without prefix `keg`', () => {
@@ -128,13 +128,13 @@ describe('injectHelpers', () => {
         , true)
       }
       // array classnames
-      const selector = getSelector([`test-class`, `test-keg-2`, `keg-text`], `my-test-styles`, 'keg')
+      const {selector} = getSelector([`test-class`, `test-keg-2`, `keg-text`], `my-test-styles`, 'keg')
       const includeTestClass = includes(selector, [`test-class`, `test-keg-2`])
       expect(includeTestClass).toBe(false)
       expect(selector.includes('keg-text')).toBe(true)
 
       // string classnames
-      const selector2 = getSelector(`keg-text test-class test-class-2`, `my-test-styles`, 'keg')
+      const {selector: selector2} = getSelector(`keg-text test-class test-class-2`, `my-test-styles`, 'keg')
       const includeTestClass2 = includes(selector2, [`test-class`, `test-class-2`])
       expect(includeTestClass2).toBe(false)
       expect(selector.includes('keg-text')).toBe(true)

--- a/repos/re-theme/src/styleInjector/injectHelpers.js
+++ b/repos/re-theme/src/styleInjector/injectHelpers.js
@@ -126,7 +126,7 @@ export const filterRules = (style, filter) => {
  * @param {string} cssString - Css rules for the className in string format
  * @param {string=} filterPrefix - optional prefix to filter by
  * 
- * @returns {string} - Hashed version of the string
+ * @returns {{hashClass:string, selector:string}} - returns selector string and hashClass string
  */
 export const getSelector = (className, cssString, filterPrefix) => {
 
@@ -140,13 +140,16 @@ export const getSelector = (className, cssString, filterPrefix) => {
   const selector = !exists(className)
     ? false
     : isArr(className)
-      ? className.filter(filterWithPrefix).join('.').trim()
-      : isStr(className) && className.split(' ').filter(filterWithPrefix).join('.').trim()
+      ? className.filter(filterWithPrefix).pop()
+      : isStr(className) && className.split(' ').filter(filterWithPrefix).pop()
 
-
-  return selector
-    ? `.${selector}.keg-${hashString(cssString)}`.trim()
-    : `.keg-${hashString(cssString)}`.trim()
+  const hashClass = `keg-${hashString(cssString)}`
+  return {
+    hashClass,
+    selector: selector
+      ? `.${selector.trim()}.${hashClass}`.trim()
+      : `.${hashClass}`.trim()
+  } 
 }
 
 /**

--- a/repos/re-theme/src/styleInjector/useStyleTag.js
+++ b/repos/re-theme/src/styleInjector/useStyleTag.js
@@ -93,7 +93,7 @@ export const useStyleTag = (style, className='', config) => {
     const { blocks, filtered } = convertToCss(style, config)
 
     // Create a unique selector based on the className and built blocks
-    const selector = getSelector(className, blocks.join(''), 'keg')
+    const {hashClass, selector} = getSelector(className, blocks.join(''), 'keg')
 
     // Adds the css selector ( className ) to each block
     const css = blocks.reduce((css, block) => {
@@ -105,11 +105,10 @@ export const useStyleTag = (style, className='', config) => {
     }, { all: '', rules: [] })
 
     addStylesToDom(selector, css, themeKey)
-
     return {
       css,
       filteredStyle: filtered,
-      classList: selector.split('.').filter(cls => cls)
+      classList: eitherArr(className, [className]).concat([hashClass]),
     }
   }, [style, className, themeSize, themeKey, config])
 


### PR DESCRIPTION
**Ticket**: [issue_id](https://jira.simpleviewtools.com/browse/ZEN-447)
`[semver]: patch`
> - related to this tap PR: https://github.com/simpleviewinc/tap-events-force/pull/86

## Context

* we removed non keg classnames from both the selector and classList on https://jira.simpleviewtools.com/browse/ZEN-431
* what we shouldve done is remove it form the selector only

## Goal

- non `keg` classname should only be filtered out on the selectors. NOT classList
## Updates

- injectHelpers unit tests update
- updated getSelector to return an object instead of a string
- updated useStyleTag so it would filter out the non keg selectors but still keep it in the classList

## Testing
* run `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-447-demo`
* navigate to http://evf-ZEN-447-demo.local.kegdev.xyz
* inspect the `select` button or any other components that you know have an `ef-` class on it
* verify that the `ef-` className does not exists on the selector, but does exists in the classList
   * ![image](https://user-images.githubusercontent.com/3317835/98161366-dc055300-1e9c-11eb-8f13-9c54cd914494.png)

* pull this branch
* run `keg retheme && yarn test`
* verify all retheme unit tests passes
