### PR TITLE
Zen 385 remove ext deps

### DIFF
--- a/repos/keg-cli/containers/tap/mutagen.yml
+++ b/repos/keg-cli/containers/tap/mutagen.yml
@@ -19,6 +19,17 @@ sync:
         - "/build"
         - "/docs"
 actions:
+  resolver:
+    install:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
+      privileged: true
+      cmds:
+        - yarn install
+    att:
+      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
+      privileged: true
+      cmds:
+        - bash
   core:
     install:
       location: /keg/tap/node_modules/keg-core

--- a/repos/keg-cli/package.json
+++ b/repos/keg-cli/package.json
@@ -31,7 +31,7 @@
     "view:reports": "open reports/coverage/lcov-report/index.html"
   },
   "dependencies": {
-    "@keg-hub/args-parse": "0.0.1",
+    "@keg-hub/args-parse": "6.1.0",
     "@keg-hub/ask-it": "0.0.1",
     "@keg-hub/jsutils": "0.0.1",
     "@keg-hub/spawn-cmd": "0.0.1",

--- a/repos/keg-cli/src/tasks/docker/package/run.js
+++ b/repos/keg-cli/src/tasks/docker/package/run.js
@@ -230,7 +230,7 @@ const dockerPackageRun = async args => {
       envs: {
         ...contextEnvs,
         [KEG_DOCKER_EXEC]: KEG_EXEC_OPTS.packageRun,
-        KEG_EXEC_CMD: command || contextEnvs.KEG_EXEC_CMD,
+        ...((command || contextEnvs.KEG_EXEC_CMD) && { KEG_EXEC_CMD: command || contextEnvs.KEG_EXEC_CMD })
       },
     })
   }

--- a/repos/keg-cli/src/tasks/docker/package/run.js
+++ b/repos/keg-cli/src/tasks/docker/package/run.js
@@ -230,6 +230,7 @@ const dockerPackageRun = async args => {
       envs: {
         ...contextEnvs,
         [KEG_DOCKER_EXEC]: KEG_EXEC_OPTS.packageRun,
+        KEG_EXEC_CMD: command || contextEnvs.KEG_EXEC_CMD,
       },
     })
   }

--- a/repos/keg-cli/yarn.lock
+++ b/repos/keg-cli/yarn.lock
@@ -1039,13 +1039,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@keg-hub/args-parse@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@keg-hub/args-parse/-/args-parse-0.0.1.tgz#6010a23a258b29631905a82832f6bccbf189c968"
-  integrity sha512-e3jluRc6LK94y+IckUD5RqqhNeGhrWV9JSyRsRkWp1JCgMkwRRneqJoq9uI91cCvLZAI7p/JGFbgAsHiVqXx/Q==
+"@keg-hub/args-parse@6.2.1":
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/@keg-hub/args-parse/-/args-parse-6.1.0.tgz#10b39cca290a46e61d3ffb517be74125c108b469"
+  integrity sha512-LKkZvTMW5Oof9xlSuL2MXgGoATX+lDa5mVCqPhFW79mSfs9mrBcjJRT/LNjWG2T4Qs9euRnWKM8cHGg7EjddhA==
   dependencies:
     "@keg-hub/ask-it" "0.0.1"
-    "@keg-hub/jsutils" "0.0.1"
+    "@keg-hub/jsutils" "6.1.0"
     app-root-path "3.0.0"
 
 "@keg-hub/ask-it@0.0.1":
@@ -1061,6 +1061,11 @@
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@keg-hub/jsutils/-/jsutils-0.0.1.tgz#6be5fd8398324c51a320f9f8460dbcdcf9faec24"
   integrity sha512-1oAyR0FuHb6ICHd1sacvGhm0O4/w/BDT+RNQO13Lcy1hh7QgAibOG7ylioPFkOQWBFN1nCMdgW9xRVe3peEUVQ==
+
+"@keg-hub/jsutils@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/@keg-hub/jsutils/-/jsutils-6.1.0.tgz#880329665ac2a173d5fbadfe4ff8f2eedc94c0cc"
+  integrity sha512-h8uE8UBUqGeI0QWJL+93gG2/SuV9Z7xoELIwtT0Zp1qJNQRlW91U/23S+Mt1V91cfZ3og0Dx3LcDknwWKXisgQ==
 
 "@keg-hub/spawn-cmd@0.0.1":
   version "0.0.1"

--- a/repos/keg-components/configs/babel.config.js
+++ b/repos/keg-components/configs/babel.config.js
@@ -3,5 +3,6 @@ module.exports = {
   plugins: [
     [ '@babel/plugin-proposal-optional-chaining' ],
     [ '@babel/plugin-proposal-class-properties' ],
-  ]
+    ['transform-react-remove-prop-types', { removeImport: 'true' }],
+  ],
 }

--- a/repos/keg-components/configs/rollup.config.js
+++ b/repos/keg-components/configs/rollup.config.js
@@ -165,6 +165,7 @@ const shared = {
       "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
       "process.env.RE_PLATFORM": JSON.stringify(platform),
       "process.env.PLATFORM": JSON.stringify(platform),
+      "import 'prop-types';": "",
     }),
     resolve(),
     json(),

--- a/repos/keg-components/package.json
+++ b/repos/keg-components/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/simpleviewinc/keg-hub#readme",
   "license": "MIT",
   "scripts": {
+    "docker:build": "bash ./scripts/dockerBuild.sh",
     "build": "yarn clean:build; NODE_ENV=production rollup -c ./configs/rollup.config.js",
     "clean": "yarn clean:nm",
     "clean:build": "rimraf build; mkdir build; mkdir build/cjs; mkdir build/esm; yarn copy:indexes",

--- a/repos/keg-components/package.json
+++ b/repos/keg-components/package.json
@@ -79,6 +79,8 @@
     "babel-preset-expo": "8.3.0",
     "babel-plugin-module-resolver": "4.0.0",
     "babel-plugin-react-native-web": "0.14.7",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "babel-preset-react-native": "4.0.1",
     "eslint": "7.4.0",
     "eslint-plugin-jest": "23.18.0",
     "eslint-plugin-react": "7.20.0",

--- a/repos/keg-components/scripts/dockerBuild.sh
+++ b/repos/keg-components/scripts/dockerBuild.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# 
+# Command to build the keg-sessions component with in the tap docker container, then copy to the host build folder
+# This ensures a consistent environment when compiling the component
+# At somepoint we could also automate pushing the component to NPM / Github / etc..
+# 
+
+if [[ -z "$KEG_CLI_PATH" ]]; then
+  echo "[ KEG ERROR ] Keg-CLI path not set! Ensure the env \"KEG_CLI_PATH\" is set before running this command!" >&2
+  exit 1
+fi
+
+# Ensure the keg-cli is loaded
+source $KEG_CLI_PATH/keg
+
+# Move to the events-force directory
+keg components
+
+# Path to the taps local build folder
+LOCAL_BUILD_DIR=$(pwd)/build
+
+# Remove the local build folder if it exists
+if [[ -d "$LOCAL_BUILD_DIR" ]]; then
+  rm -rf $LOCAL_BUILD_DIR
+fi
+
+# Run the build command in the tap docker container
+keg d ex context=components cmd=\"yarn build\"
+
+# Command to build keg-component, and copy it from the docker container
+# This is just to test building keg-components to ensure changes are reflected in that build
+keg d cp context=components source=docker remote=/keg/keg-components/build local=$LOCAL_BUILD_DIR

--- a/repos/keg-components/src/components/svgIcon/svgIcon.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.js
@@ -75,6 +75,9 @@ export const SvgIcon = props => {
     fillRule,
     size,
     stroke,
+    strokeWidth,
+    strokeLinecap,
+    strokeLinejoin,
     style = noPropObj,
     svgFill,
     viewBox,
@@ -94,6 +97,9 @@ export const SvgIcon = props => {
     >
       <Path
         stroke={colorStyle.stroke}
+        strokeWidth={strokeWidth}
+        strokeLinecap={strokeLinecap}
+        strokeLinejoin={strokeLinejoin}
         fill={colorStyle.fill}
         d={delta}
         fillRule={fillRule}

--- a/repos/keg-components/src/components/svgIcon/svgIcon.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.js
@@ -1,8 +1,22 @@
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import { get, noPropObj } from '@keg-hub/jsutils'
+import { get, deepMerge, isArr, noPropObj } from '@keg-hub/jsutils'
 import Svg, { Path } from 'react-native-svg'
 import { useTheme } from '@keg-hub/re-theme'
+
+/**
+ * Custom hook to check if the size prop is an array, and merge it. Otherwise just returns the style object
+ * @param {Object|Array=} style - Style object used to apply custom styles to the component
+ *
+ * @returns {Object} - Merged style object
+ */
+const useIconStyle = style => {
+  return useMemo(() => {
+    return isArr(style)
+      ? deepMerge(...style)
+      : style
+  }, [ style ])
+}
 
 /**
  * Custom hook to find the size from the props and styles
@@ -12,15 +26,15 @@ import { useTheme } from '@keg-hub/re-theme'
  *
  * @returns {Object} - Contains the height and width props for the Svg element
  */
-const useSize = (size, style, theme) => {
+const useSize = (size, width, height, style, theme) => {
   return useMemo(() => {
     const iconSize = size || get(style, 'fontSize')
     const themeSize = get(theme, 'typography.default.fontSize', 15) * 2
     return {
-      height: iconSize || get(style, 'height', themeSize),
-      width: iconSize || get(style, 'width', themeSize),
+      height: height || iconSize || get(style, 'height', themeSize),
+      width: width || iconSize || get(style, 'width', themeSize),
     }
-  }, [ size, style ])
+  }, [ size, width, height, style ])
 }
 
 /**
@@ -73,6 +87,7 @@ export const SvgIcon = props => {
     delta,
     fill,
     fillRule,
+    height,
     size,
     stroke,
     strokeWidth,
@@ -81,29 +96,31 @@ export const SvgIcon = props => {
     style = noPropObj,
     svgFill,
     viewBox,
+    width,
     ...attrs
   } = props
 
+  const iconStyle = useIconStyle(style)
   const theme = useTheme()
-  const sizeStyle = useSize(size, style, theme)
-  const colorStyle = useColor(fill, stroke, color, border, style, theme)
+  const sizeStyle = useSize(size, width, height, iconStyle, theme)
+  const colorStyle = useColor(fill, stroke, color, border, iconStyle, theme)
 
   return (
     <Svg
       {...attrs}
       fill={svgFill}
       viewBox={viewBox}
-      style={[ style, sizeStyle ]}
+      style={[ iconStyle, sizeStyle ]}
     >
       <Path
+        clipRule={clipRule}
+        d={delta}
+        fill={colorStyle.fill}
+        fillRule={fillRule}
         stroke={colorStyle.stroke}
         strokeWidth={strokeWidth}
         strokeLinecap={strokeLinecap}
         strokeLinejoin={strokeLinejoin}
-        fill={colorStyle.fill}
-        d={delta}
-        fillRule={fillRule}
-        clipRule={clipRule}
       />
     </Svg>
   )
@@ -118,7 +135,7 @@ SvgIcon.propTypes = {
   fillRule: PropTypes.string,
   size: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
   stroke: PropTypes.string,
-  style: PropTypes.object,
+  style: PropTypes.oneOfType([ PropTypes.object, PropTypes.array ]),
   svgFill: PropTypes.string,
   viewBox: PropTypes.string,
 }

--- a/repos/keg-components/yarn.lock
+++ b/repos/keg-components/yarn.lock
@@ -5735,6 +5735,18 @@ babel-plugin-transform-react-remove-prop-types@0.4.24:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
   integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
+babel-plugin-transform-regenerator@^6.5.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
+  dependencies:
+    regenerator-transform "^0.10.0"
+
 babel-plugin-transform-regexp-constructors@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz#58b7775b63afcf33328fae9a5f88fbd4fb0b4965"

--- a/repos/keg-core/app.json
+++ b/repos/keg-core/app.json
@@ -116,16 +116,28 @@
             "babel-preset-expo"
           ],
           "plugins": [
-            [
-              "react-native-web"
-            ]
-          ]
+            ["react-native-web"]
+          ],
+          "env": {
+            "production": {
+              "plugins": [
+                ["transform-react-remove-prop-types", { "removeImport": "true", "ignoreFilenames": ["node_modules"] }]
+              ]
+            }
+          }
         },
         "native": {
           "presets": [
             "babel-preset-expo"
           ],
-          "plugins": []
+          "plugins": [],
+          "env": {
+            "production": {
+              "plugins": [
+                ["transform-react-remove-prop-types", { "removeImport": "true", "ignoreFilenames": ["node_modules"] }]
+              ]
+            }
+          }
         }
       }
     },

--- a/repos/keg-core/package.json
+++ b/repos/keg-core/package.json
@@ -62,6 +62,7 @@
     "babel-eslint": "10.1.0",
     "babel-loader": "8.1.0",
     "babel-plugin-module-resolver": "4.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-preset-env": "1.7.0",
     "babel-preset-expo": "8.3.0",
     "enzyme": "3.11.0",

--- a/repos/tap-resolver/babel.config.js
+++ b/repos/tap-resolver/babel.config.js
@@ -1,6 +1,8 @@
 const runSetup = require('./src/runSetup')
+const { deepMerge } = require('@keg-hub/jsutils')
 const { getPlatformData, getResolverFile, validateBabel } = require('./src/babel')
 const { PLATFORM, NODE_ENV, KEG_COMPONENT_RESOLVER } = process.env
+const babelEnv = NODE_ENV || 'development'
 
 /**
  * Sets up the babel config based on the PLATFORM ENV and the passed in options
@@ -57,7 +59,18 @@ const babelSetup = options => {
     ]
   }
 
-  return { ...babel, env: { test: { ...babel }}}
+  return {
+    ...babel,
+    // Merge the babel.env config with the generated babel config for the current environemtn
+    // This ensures any custom env config options are added
+    // By default babel will replace the default config with items defined for the environment
+    // By merging here, we can ensure the both the custom and generated configs are added
+    // This also means config should NOT be duplicated per environment
+    env: deepMerge(
+      babelOpts.env,
+      { [babelEnv]:  babel }
+    )
+  }
 
 }
 


### PR DESCRIPTION
**Ticket**:
* [ZEN-384](https://jira.simpleviewtools.com/browse/ZEN-384)
* [ZEN-385](https://jira.simpleviewtools.com/browse/ZEN-385)

> **IMPORTANT**
> This PR should be tested alongside these PRs
> [Tap-Events-Force](https://github.com/simpleviewinc/tap-events-force/pull/87)
> [Keg-Consumer](https://github.com/simpleviewinc/keg-test-consumer/pull/6)

## Context
* Currently, component prop-types are being included in the production bundle
* They don't need to be since they aren't going to be used in production

## Goal

* Clean up the keg-components exports
* Remove prop-types from the keg-components export

## Updates

* `repos/keg-cli/containers/tap/mutagen.yml`
  * Added tap resolver sync actions
* `repos/keg-cli/package.json`
  * Updated deps versions
* `repos/keg-components/configs/babel.config.js` && `repos/keg-components/package.json`
  * Added `transform-react-remove-prop-types` babel plugin
  * Auto-removes prop types from the production export
* `repos/keg-components/configs/jest.config.js`
  * Fix keg-components tests
  * They are currently breaking on the develop branch
* `repos/keg-components/configs/rollup.config.js`
 * Removed the proptypes import form the production build
* `repos/keg-components/src/assets/icons/svgIcon/svgIcon.js`
  * Added bug fixes to SVG Icon
  * Required for tap-events-force icons to all use the SVG icon component 
* `repos/keg-core/app.json`
  * Updated to use the `transform-react-remove-prop-types` babel plugin
* `repos/tap-resolver/babel.config.js`
  * Updated to include the `.env` of the babel config from the keg and tap configs
  * This allows setting custom babel configs based on environment
  * This way proptypes are removed only on production builds
* `repos/keg-cli/src/tasks/docker/package/run.js`
  * Small fix to overwrite the `KEG_EVEC_CMD` when overwriting the default command

## Testing

**Test 1**
* Run the command => `keg dpg run docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:zen-385-remove-ext-deps`
  * Navigate to http://components-zen-385-remove-ext-deps.local.kegdev.xyz/?path=/story/box-textbox--outlined
  * Ensure the components work as expected

**Test 2**
* Pull this PR, and start the keg-components container
* Run the command => `keg dpg run docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:zen-385-remove-ext-deps test`
* Ensure the tests are run for keg-components
* Ensure all tests pass

**Test 3**
* `keg components start --build`
  * We include the `--build` option, so it will re-build the container and install the added babel plugins
  * Once it's running, navigate to the `keg-components` directory and run the `docker:build` script
    * `keg components && yarn docker:build`
 * Inspect the export, and ensure the propTypes were removed
 * Looks like this http://snpy.in/wTkuw3
 * **Important** - You will still see some reference to `propTypes` that copy the React-Native components propTypes
  * This is expected and can not be removed
  * They are don't add any extra code bloat, so they are a non-issue








