### PR TITLE
Fix proxy tunnel

### DIFF
--- a/repos/keg-cli/src/libs/docker/helpers.js
+++ b/repos/keg-cli/src/libs/docker/helpers.js
@@ -171,7 +171,18 @@ const jsonOutput = (data, skipError) => {
           built.rootId = built.repository.indexOf('/') !== -1
             ? built.repository.split('/').pop()
             : built.repository
+        else if(built.image && isStr(built.labels)){
 
+          // Convert container labels from a string to an object
+          built.labelsObj = built.labels.split(',')
+            .reduce((labelObj, label) => {
+              const [ key, value ] = label.split('=')
+              key && value && (labelObj[key] = value)
+
+              return labelObj
+            }, {})
+
+        }
         const existing = indexMap[built.id] && items[ indexMap[built.id] ]
 
         // De-dupes the returned images

--- a/repos/keg-cli/src/tasks/docker/tunnel.js
+++ b/repos/keg-cli/src/tasks/docker/tunnel.js
@@ -134,13 +134,13 @@ const onStdOut = (qr, log, tunnelSet=false) => {
     if(tunnelSet || data.indexOf(`msg="started tunnel"`) === -1)
       return tunnelSet && log && Logger.stdout(data)
 
-    // Set tunnel set to turn, so we can start logging
+    // Set tunnel set to true so we can start logging
     tunnelSet = true
 
-    const tunnelUrl = data.split(`url=`)[1].split(' ')[0]
     const localUrl = data.split(`addr=`)[1].split(' ')[0]
-
     Logger.spacedMsg('Source:', Logger.color('magenta', localUrl))
+
+    const tunnelUrl = data.split(`url=`)[1].split(' ')[0].split('\n')[0]
     Logger.spacedMsg('Tunnel:', Logger.color('green', tunnelUrl))
 
     // If no qr code is set then just return

--- a/repos/keg-cli/src/tasks/docker/tunnel.js
+++ b/repos/keg-cli/src/tasks/docker/tunnel.js
@@ -217,8 +217,8 @@ module.exports = {
       },
       log: {
         description: 'Log output from the tunnel process',
-        example: 'keg docker tunnel --no-log',
-        default: true
+        example: 'keg docker tunnel --log',
+        default: false
       }
     }
   }

--- a/repos/keg-cli/src/tasks/docker/tunnel.js
+++ b/repos/keg-cli/src/tasks/docker/tunnel.js
@@ -1,7 +1,104 @@
 const ngrok = require('ngrok')
-const qrcode = require('qrcode-terminal')
 const { Logger } = require('KegLog')
+const qrcode = require('qrcode-terminal')
 const { DOCKER } = require('KegConst/docker')
+const { isObj, isStr } = require('@keg-hub/jsutils')
+const { CONTAINER_PREFIXES } = require('KegConst/constants')
+const { containerSelect } = require('KegUtils/docker/containerSelect')
+const { PACKAGE, IMAGE } = CONTAINER_PREFIXES
+
+/**
+ * Adds the http protocol to the found host header if it does not exist
+ * @function
+ * @param {string} hostHeader - Host Head used in the docker container application
+ *
+ * @returns {string} - Host Header with the http protocol added
+ */
+const addHostHeaderProto = hostHeader => {
+  return hostHeader.indexOf('http') === 0
+    ? hostHeader
+    : `http://${hostHeader}`
+}
+
+
+/**
+ * Adds the KEG_PROXY_HOST if it does not exist on the passed in host
+ * @function
+ * @param {string} host - Custom host to use for the proxy tunnel
+ *
+ * @returns {string} - Host Header with the KEG_PROXY_HOST added if needed
+ */
+const buildCustomHostHeader = host => {
+  const fullHost = host.indexOf('.') !== -1
+    ? host
+    : `${host}.${DOCKER.KEG_PROXY_HOST}`
+  
+  return addHostHeaderProto(fullHost)
+}
+
+/**
+ * Gets the host name from the containers name
+ * <br/>Removes PACKAGE && IMAGE from the name
+ * <br/>This will fail with using a NON-injected tap and no label exists
+ * @function
+ * @param {string} containerName - Name of the container
+ *
+ * @returns {string} - Name of the container with the KEG_PROXY_HOST added
+ */
+const getHostFromName = (containerName) => {
+  const cleaned = containerName.replace(`${PACKAGE}-`, '').replace(`${IMAGE}-`, '')
+
+  return `${cleaned}.${DOCKER.KEG_PROXY_HOST}`
+}
+
+/**
+ * Gets the host header from the docker containers labels
+ * @function
+ * @param {Object} container - Docker container object from the docker cli
+ *
+ * @returns {string} - Host found in the docker containers labels
+ */
+const getHostFromLabel = (container={}) => {
+  let hostHeader
+  const labelsStr = container.labels
+  const labelsObj = container.labelsObj
+  
+  if(!isObj(labelsObj) && isStr(labelsStr)){
+    return labelsStr.indexOf('.rule=Host(`') === -1
+      ? labelsStr.split('.rule=Host(`')[1].split('`),')[0]
+      : false
+  }
+
+  hostHeader = Object.values(labelsObj)
+    .reduce((host, value) => {
+      return host || !value || value.indexOf('Host(`') === -1
+        ? host
+        : value.split('`')[1]
+    }, '')
+
+  return hostHeader || Object.entries(labelsObj)
+    .reduce((host, [key, value]) => {
+      return key === `com.keg.proxy.domain`
+        ? `${value}.${DOCKER.KEG_PROXY_HOST}`
+        : host
+    }, '')
+}
+
+/**
+ * Asks the user to select a docker container
+ * <br/>Then gets the host header from it's name or labels
+ * @function
+ * @param {string} host - Custom host name to use passed in from the command line
+ *
+ * @returns {string} - Host Header found from the selected docker container
+ */
+const getHostHeader = async host => {
+  if(host) return buildCustomHostHeader(host)
+
+  const container = await containerSelect(containers => containers.filter(container => container.name !== 'keg-proxy'))
+
+  return addHostHeaderProto(getHostFromLabel(container) || getHostFromName(container.name))
+}
 
 /**
  * Create a public tunnel the the url (by default, to `kegdev.xyz`)
@@ -14,14 +111,19 @@ const { DOCKER } = require('KegConst/docker')
  */
 const tunnel = async args => {
   const { params } = args
-  const { qr, source, port } = params
+  const { qr, source, port, host } = params
 
-  const dockerIP = DOCKER.PREFIXED.KEG_DOCKER_IP
-  const srcUri = source || port || dockerIP
+  const hostHeader = await getHostHeader(host)
+  !hostHeader && Logger.warn('Could not find a valid host header from container meta-data!')
+
+  const srcUri = source || port || `${DOCKER.PREFIXED.KEG_DOCKER_IP}:80`
   
   Logger.header('Starting tunnel...', 'white')
 
-  const tunnelUrl = await ngrok.connect(srcUri)
+  const tunnelUrl = await ngrok.connect({
+    host_header: hostHeader,
+    addr: srcUri
+  })
 
   Logger.spacedMsg('Source:', Logger.color('magenta', srcUri))
   Logger.spacedMsg('Tunnel:', Logger.color('green', tunnelUrl))
@@ -38,6 +140,11 @@ module.exports = {
     description: 'Creates a public tunnel to the running docker container available at kegdev.xyz',
     example: 'keg docker tunnel <options>',
     options: {
+      host: {
+        alias: [ 'header', 'rewrite' ],
+        description: "Override the host header of the tunnel. By default, it uses the first found docker-package url",
+        example: "keg docker tunnel --host core-develop"
+      },
       qr:  {
         description: 'if true, `tunnel` will display a qr code that encodes the tunnel\'s public uri. This can make connecting a mobile device to the tunnel much easier.',
         example: 'keg docker tunnel --qr false',

--- a/repos/keg-cli/src/tasks/docker/tunnel.js
+++ b/repos/keg-cli/src/tasks/docker/tunnel.js
@@ -1,11 +1,16 @@
-const ngrok = require('ngrok')
+const path = require('path')
 const { Logger } = require('KegLog')
+const platform = require('os').platform()
 const qrcode = require('qrcode-terminal')
 const { DOCKER } = require('KegConst/docker')
 const { isObj, isStr } = require('@keg-hub/jsutils')
-const { CONTAINER_PREFIXES } = require('KegConst/constants')
+const { CONTAINER_PREFIXES, CLI_ROOT } = require('KegConst/constants')
 const { containerSelect } = require('KegUtils/docker/containerSelect')
 const { PACKAGE, IMAGE } = CONTAINER_PREFIXES
+const { pipeCmd } = require('KegProc')
+
+const NODE_MODULES_BIN = path.join(CLI_ROOT, `node_modules/.bin`)
+const NGROK_BIN = './ngrok' + (platform === 'win32' ? '.exe' : '')
 
 /**
  * Adds the http protocol to the found host header if it does not exist
@@ -100,6 +105,57 @@ const getHostHeader = async host => {
   return addHostHeaderProto(getHostFromLabel(container) || getHostFromName(container.name))
 }
 
+// TODO: Add better parsing for the log message
+/**
+ * Callback for the standard out of the ngrok process
+ * <br/>Looks for the started tunnel message, and parses the ngrok url
+ * <br/>Displays a QR code with or the ngrok url for easy access
+ * @function
+ * @param {boolean} qr - Should a qr code be displayed
+ * @param {boolean} log - Should messages be logged
+ * @param {boolean} tunnelSet - Has the ngrok tunnel be setup
+ *
+ * @returns {function} - Standard out callback for the ngrok process
+ */
+const onStdOut = (qr, log, tunnelSet=false) => {
+
+ /**
+  * Return a callback used by the ngrok process to log message
+  * <br/>This is used to parse the ngrok tunnel url so it can be displayed 
+  * <br/>We also use it to create a QR code for easy access
+  * @function
+  * @param {string} data - Output from the standard out ngrok process
+  *
+  * @returns {void}
+  */
+  return data => {
+
+    // If logging is turned on and it's not the started tunnel message, then log the data
+    if(tunnelSet || data.indexOf(`msg="started tunnel"`) === -1)
+      return tunnelSet && log && Logger.stdout(data)
+
+    // Set tunnel set to turn, so we can start logging
+    tunnelSet = true
+
+    const tunnelUrl = data.split(`url=`)[1].split(' ')[0]
+    const localUrl = data.split(`addr=`)[1].split(' ')[0]
+
+    Logger.spacedMsg('Source:', Logger.color('magenta', localUrl))
+    Logger.spacedMsg('Tunnel:', Logger.color('green', tunnelUrl))
+
+    // If no qr code is set then just return
+    if(!qr) return
+
+    // Show a qr code on the terminal that the user can use to quickly access the tunnel on a mobile device
+    qr && qrcode.generate(tunnelUrl, { small: false })
+    // Set the qr to false to we only log out one qr code
+    qr = false
+
+    Logger.empty()
+  }
+
+}
+
 /**
  * Create a public tunnel the the url (by default, to `kegdev.xyz`)
  * @function
@@ -111,7 +167,7 @@ const getHostHeader = async host => {
  */
 const tunnel = async args => {
   const { params } = args
-  const { qr, source, port, host } = params
+  const { qr, source, port, host, log } = params
 
   const hostHeader = await getHostHeader(host)
   !hostHeader && Logger.warn('Could not find a valid host header from container meta-data!')
@@ -120,16 +176,16 @@ const tunnel = async args => {
   
   Logger.header('Starting tunnel...', 'white')
 
-  const tunnelUrl = await ngrok.connect({
-    host_header: hostHeader,
-    addr: srcUri
+  let ngrokCmd = `${NGROK_BIN} http --log=stdout`
+  hostHeader
+    ? (ngrokCmd += ` -host-header=rewrite ${hostHeader}`)
+    : (ngrokCmd += ` ${srcUri}`)
+
+  await pipeCmd(ngrokCmd.trim(), {
+    cwd: NODE_MODULES_BIN,
+    onStdOut: onStdOut(qr, log),
   })
 
-  Logger.spacedMsg('Source:', Logger.color('magenta', srcUri))
-  Logger.spacedMsg('Tunnel:', Logger.color('green', tunnelUrl))
-
-  // show a qr code on the terminal that the user can use to quickly access the tunnel on a mobile device
-  qr && qrcode.generate(tunnelUrl, { small: false })
 }
 
 module.exports = {
@@ -158,6 +214,11 @@ module.exports = {
       port: {
         description: 'optional override for the source of the tunnel, using this specified port of localhost instead.',
         example: 'keg docker tunnel --port 19006',
+      },
+      log: {
+        description: 'Log output from the tunnel process',
+        example: 'keg docker tunnel --no-log',
+        default: true
       }
     }
   }

--- a/repos/keg-cli/src/utils/getters/getInternalIp.js
+++ b/repos/keg-cli/src/utils/getters/getInternalIp.js
@@ -14,7 +14,7 @@ const getInternalIp = () => {
     return ipAddress || interfaces[ifName].reduce((ip, iFace) => {
       const { family, internal, address } = iFace
 
-      return ip || (family !== 'IPv4' || internal !== false || address === '127.0.0.1')
+      return ip || (family !== 'IPv4' || internal !== false || address === '127.0.0.1' || address.indexOf('169.254') === 0 )
           ? ip
           : address
 


### PR DESCRIPTION
## Context

* With the changes to use the key-proxy, the proxy tunnel no longer works


## Goal

* Allow the proxy tunnel to work with the keg-proxy

## Updates

* `repos/keg-cli/src/libs/docker/helpers.js`
  * Added helper to convert string labels from docker images into a `labels` object
* `repos/keg-cli/src/tasks/docker/tunnel.js`
  * Cleaned up code to allow running a tunnel with the keg-porxy
  * Will now ask for which container to proxy when a host is not passed as an option
  * Updated to call ngrok binary directly instead of the node wrapper
    * The node wrapper didn't allow all options
    * Added basic logging, but this could be improved if needed
* `repos/keg-cli/src/utils/getters/getInternalIp.js`
  * Small fix to a test, to filter out `Link-Local` Ips

## Testing

**Setup**
* Switch to this PR => `keg && keg pr 74`
* Run the docker package => `keg evf pack run docker.pkg.github.com/simpleviewinc/keg-packages/tap:keg-theme-as-functions`
* Navagate to this URL to ensure it's working => http://evf-keg-theme-as-functions.local.kegdev.xyz
  * Ensure the tap is loading

**Test 1**
* Open a new terminal tab
* Run command `keg d tunnel`
  * It should ask you to select a container
  * Select the `package-tap-keg-theme-as-functions` container
* It should print out `starting tunnel`
* It should then print out the Tunnel URL
  * [Looks like this ](http://snpy.in/Qh3EKZ)
  * Copy the Tunnel link into the browser
    * It should route to the container
  * Ensure the tunnel url works as expected 

**Test 2**
* Stop the running tunnel from test 1
* Run this command `keg d tunnel invalid-host`
  * It should do exactly the same thing as it did in **Test 1**
  * **Except** the source host should be http://invalid-host.local.kegdev.xyz:80
    * [Looks like this](http://snpy.in/2hcZ5N)
* If you try to navigate to the host is will fail to load the tap
* This test proves
  * The passed in option overrides the default
  * It will not ask you to select a container when you pass in the host option

**Test 3**
* Stop the running tunnel from test 2
* Run this command `keg d tunnel evf-keg-theme-as-functions`
  * It should do exactly the same thing as it did in **Test 1**
  * Go to the printed out tunnel url in the browser
  * Ensure it works as expected, because the passed in host is correct

**Test 4**
* Run command `keg cli test`
  * Ensure all tests pass
