### PR TITLE
Log Branch on Image/Container Removal

### DIFF
--- a/repos/keg-cli/src/__mocks__/libs/docker/docker.js
+++ b/repos/keg-cli/src/__mocks__/libs/docker/docker.js
@@ -354,6 +354,9 @@ const docker = {
             return data.id === image || data.image === image || data.name === image
           })
     }),
+    list: jest.fn(() => {
+      return Object.values(global.testDocker.images)
+    }),
     exists: jest.fn(image => {
       return global.testDocker.images[image] ||
         Object.values(global.testDocker.images)

--- a/repos/keg-cli/src/utils/docker/__tests__/containerSelect.js
+++ b/repos/keg-cli/src/utils/docker/__tests__/containerSelect.js
@@ -1,0 +1,45 @@
+const { docker } = require('KegMocks/libs/docker')
+const { AskIt } = require('KegMocks/ask')
+
+jest.setMock('@keg-hub/ask-it', { ask: AskIt })
+jest.setMock('KegDocCli', docker)
+jest.setMock('KegConst/envs', { KEG_ENVS: { KEG_PROXY_HOST: 'local.kegdev.xyz' }})
+
+const containers = Object.values(global.testDocker.containers)
+
+const { containerSelect } = require('../containerSelect')
+
+describe('containerSelect', () => {
+
+  beforeEach(() => {
+    AskIt.promptList.mockClear()
+    docker.container.list.mockClear()
+  })
+
+  afterAll(() => jest.resetAllMocks())
+
+  it('should call docker.container.list to get a list of all containers', async () => {
+    expect(docker.container.list).not.toHaveBeenCalled()
+    await containerSelect()
+    expect(docker.container.list).toHaveBeenCalled()
+  })
+
+  it('should call a filter function on all containers if its passed in', async () => {
+    const filter = jest.fn(cont => cont)
+    await containerSelect(filter)
+    expect(filter).toHaveBeenCalled()
+  })
+
+  it('should call ask.promptList', async () => {
+    expect(AskIt.promptList).not.toHaveBeenCalled()
+    await containerSelect()
+    expect(AskIt.promptList).toHaveBeenCalled()
+  })
+
+  it('should return the selected container', async () => {
+    // Tests default to selecting the 1 position of the passed in list
+    const resp = await containerSelect()
+    expect(resp).toBe(containers[1])
+  })
+
+})

--- a/repos/keg-cli/src/utils/docker/__tests__/imageSelect.js
+++ b/repos/keg-cli/src/utils/docker/__tests__/imageSelect.js
@@ -1,0 +1,39 @@
+const { docker } = require('KegMocks/libs/docker')
+const { AskIt } = require('KegMocks/ask')
+
+jest.setMock('@keg-hub/ask-it', { ask: AskIt })
+jest.setMock('KegDocCli', docker)
+jest.setMock('KegConst/envs', { KEG_ENVS: { KEG_PROXY_HOST: 'local.kegdev.xyz' }})
+
+const images = Object.values(global.testDocker.images)
+
+const { imageSelect } = require('../imageSelect')
+
+describe('imageSelect', () => {
+
+  beforeEach(() => {
+    AskIt.promptList.mockClear()
+    docker.image.list.mockClear()
+  })
+
+  afterAll(() => jest.resetAllMocks())
+
+  it('should call docker.image.list to get a list of all images', async () => {
+    expect(docker.image.list).not.toHaveBeenCalled()
+    await imageSelect()
+    expect(docker.image.list).toHaveBeenCalled()
+  })
+
+  it('should call ask.promptList', async () => {
+    expect(AskIt.promptList).not.toHaveBeenCalled()
+    await imageSelect()
+    expect(AskIt.promptList).toHaveBeenCalled()
+  })
+
+  it('should return the selected image', async () => {
+    // Tests default to selecting the 1 position of the passed in list
+    const resp = await imageSelect()
+    expect(resp).toBe(images[1])
+  })
+
+})

--- a/repos/keg-cli/src/utils/docker/containerSelect.js
+++ b/repos/keg-cli/src/utils/docker/containerSelect.js
@@ -1,28 +1,9 @@
 const { ask } = require('@keg-hub/ask-it')
 const docker = require('KegDocCli')
-const { checkCall } = require('@keg-hub/jsutils')
+const { checkCall, get } = require('@keg-hub/jsutils')
 const { throwNoContainers } = require('../error/throwNoContainers')
-
-/**
- * @param {string} labels - all labels stored as a single csv string
- * @return {string} the domain label value
- */
-const getDomain = labels => {
-  const split = labels 
-    ? labels.split(',')
-    : []
-
-  const domain = split.reduce((result, next) => {
-    if (result) return result
-    const [ key, value ] = next.split('=')
-    return (key === 'com.keg.proxy.domain')
-      ? value
-      : result
-  }, null)
-
-  // return the domain, or if not found, the proxy's dashboard
-  return domain || 'local.kegdev.xyz'
-}
+const { kegLabelKeys } = require('KegConst/docker/labels')
+const { KEG_ENVS } = require('KegConst/envs')
 
 /**
  * Prompts user to select a container from the current docker containers
@@ -35,17 +16,16 @@ const containerSelect = async (filter, throwError=true) => {
 
   // If no containers available, then check if we should call throwError
   // Otherwise just return null
-  if(!containers.length){
+  if(!containers.length)
     return throwError
       ? throwNoContainers()
       : null
-  }
 
   // Filter the containers if filter method passed
   const filtered = checkCall(filter, containers) || containers
 
   // Get a string of each container to print to terminal
-  const items = filtered.map(cont => `${cont.name} | ${ cont.image } | ${ getDomain(cont.labels) } | ${ cont.id }`)
+  const items = filtered.map(cont => `${cont.name} | ${ cont.image } | ${ get(cont, ['labelsObj', kegLabelKeys.KEG_PROXY_DOMAIN], KEG_ENVS.KEG_PROXY_HOST) } | ${ cont.id }`)
 
   const index = await ask.promptList(
     items,

--- a/repos/keg-cli/src/utils/docker/containerSelect.js
+++ b/repos/keg-cli/src/utils/docker/containerSelect.js
@@ -4,6 +4,27 @@ const { checkCall } = require('@keg-hub/jsutils')
 const { throwNoContainers } = require('../error/throwNoContainers')
 
 /**
+ * @param {string} labels - all labels stored as a single csv string
+ * @return {string} the domain label value
+ */
+const getDomain = labels => {
+  const split = labels 
+    ? labels.split(',')
+    : []
+
+  const domain = split.reduce((result, next) => {
+    if (result) return result
+    const [ key, value ] = next.split('=')
+    return (key === 'com.keg.proxy.domain')
+      ? value
+      : result
+  }, null)
+
+  // return the domain, or if not found, the proxy's dashboard
+  return domain || 'local.kegdev.xyz'
+}
+
+/**
  * Prompts user to select a container from the current docker containers
  * @param {function} filter - Method to filter which containers are displayed. Must return array
  *
@@ -24,11 +45,11 @@ const containerSelect = async (filter, throwError=true) => {
   const filtered = checkCall(filter, containers) || containers
 
   // Get a string of each container to print to terminal
-  const items = filtered.map(cont => `${cont.name} | ${ cont.image } | ${ cont.id }`)
+  const items = filtered.map(cont => `${cont.name} | ${ cont.image } | ${ getDomain(cont.labels) } | ${ cont.id }`)
 
   const index = await ask.promptList(
     items,
-    'Docker Containers: ( Name | Image | ID )',
+    'Docker Containers: ( Name | Image | Domain | ID )',
     'Select a container:'
   )
 

--- a/repos/keg-cli/src/utils/docker/imageSelect.js
+++ b/repos/keg-cli/src/utils/docker/imageSelect.js
@@ -9,10 +9,10 @@ const imageSelect = async () => {
   const images = await docker.image.list()
   if(!images.length) return
 
-  const items = images.map(img => `${img.rootId} | ${ img.repository } | ${ img.id }`)
+  const items = images.map(img => `${img.rootId} | ${ img.repository } | ${ img.tag } | ${ img.id }`)
   const index = await ask.promptList(
     items,
-    'Docker Images: ( Root ID | Repository | ID )',
+    'Docker Images: ( Root ID | Repository | Tag | ID )',
     'Select an Image:'
   )
 


### PR DESCRIPTION
## Context

* whenever I run `keg di rm` or `keg dc rm`, I can't tell which branches those images/containers are using
* I think it's helpful to know, so you don't delete an image or container you actually want to keep

## Goal

* log out the branch in these commands

## Updates
* `repos/keg-cli/src/utils/docker/containerSelect.js`
  * updated to parse the labels domain value for logging out
* `repos/keg-cli/src/utils/docker/imageSelect.js`
  * updated to print out the tag 

## Testing
* `keg && keg pr 76`
* `keg di rm`
  * verify that the branch is logged out in the tag column
* `keg dc rm`
  * verify that the domain (which includes the branch) is logged out in the domain column
