### PR TITLE
Fix env and spelling

### DIFF
--- a/repos/keg-cli/containers/components/values.yml
+++ b/repos/keg-cli/containers/components/values.yml
@@ -13,7 +13,7 @@ env:
 
   # Defines the location of the mutagen config
   # Without it, mutagen syncs will use the default settings
-  KEG_MUTAGEN_PATH: "{{ cli.paths.containers }}/components/mutagen.yml"
+  KEG_MUTAGEN_FILE: "{{ cli.paths.containers }}/components/mutagen.yml"
   
   # The default docker-compose file path
   KEG_COMPOSE_DEFAULT: "{{ cli.paths.containers }}/components/docker-compose.yml"

--- a/repos/keg-cli/containers/core/values.yml
+++ b/repos/keg-cli/containers/core/values.yml
@@ -12,7 +12,7 @@ env:
   KEG_CONTEXT_PATH: "{{ cli.paths.core }}"
   KEG_DOCKER_FILE: "{{ cli.paths.containers }}/core/Dockerfile"
   KEG_VALUES_FILE: "{{ cli.paths.containers }}/core/values.yml"
-  KEG_MUTAGEN_PATH: "{{ cli.paths.containers }}/core/mutagen.yml"
+  KEG_MUTAGEN_FILE: "{{ cli.paths.containers }}/core/mutagen.yml"
 
   # The default docker-compose file path
   KEG_COMPOSE_DEFAULT: "{{ cli.paths.containers }}/core/docker-compose.yml"

--- a/repos/keg-cli/containers/tap/values.yml
+++ b/repos/keg-cli/containers/tap/values.yml
@@ -12,7 +12,7 @@ env:
   # Docker / Docker Compose paths
   KEG_DOCKER_FILE: "{{ cli.paths.containers }}/tap/Dockerfile"
   KEG_VALUES_FILE: "{{ cli.paths.containers }}/tap/values.yml"
-  KEG_MUTAGEN_PATH: "{{ cli.paths.containers }}/tap/mutagen.yml"
+  KEG_MUTAGEN_FILE: "{{ cli.paths.containers }}/tap/mutagen.yml"
 
   # The default docker-compose file path
   KEG_COMPOSE_DEFAULT: "{{ cli.paths.containers }}/tap/docker-compose.yml"

--- a/repos/keg-cli/src/__mocks__/injected/injectedTest.js
+++ b/repos/keg-cli/src/__mocks__/injected/injectedTest.js
@@ -65,7 +65,7 @@ const injectedTest = {
     DOC_APP_PATH: '/keg/tap',
     KEG_CONTEXT_PATH: `${homeDir}/keg-hub/taps/tap-injected-test`,
     KEG_CONTAINER_PATH: `${homeDir}/keg-hub/taps/tap-injected-test/container`,
-    KEG_MUTAGEN_PATH: `${homeDir}/keg-hub/taps/tap-injected-test/container/mutagen.yml`,
+    KEG_MUTAGEN_FILE: `${homeDir}/keg-hub/taps/tap-injected-test/container/mutagen.yml`,
     KEG_DOCKER_FILE: `${homeDir}/keg-hub/taps/tap-injected-test/container/Dockerfile`,
     KEG_VALUES_FILE: `${homeDir}/keg-hub/taps/tap-injected-test/container/values.yml`,
     KEG_COMPOSE_DEFAULT: `${homeDir}/keg-hub/taps/tap-injected-test/container/docker-compose.yml`,

--- a/repos/keg-cli/src/constants/constants.js
+++ b/repos/keg-cli/src/constants/constants.js
@@ -22,7 +22,7 @@ let GLOBAL_INJECT_FOLDER = path.join(GLOBAL_CONFIG_FOLDER, '.tmp')
 module.exports = deepFreeze({
 
   // Tasks settings
-  TASK_REQURIED: [
+  TASK_REQUIRED: [
     'prefix',
     'name',
     'action',

--- a/repos/keg-cli/src/tasks/customTasks.js
+++ b/repos/keg-cli/src/tasks/customTasks.js
@@ -1,5 +1,5 @@
 const { throwExitError } = require('KegUtils/error/throwExitError')
-const { TASK_REQURIED } = require('../constants')
+const { TASK_REQUIRED } = require('../constants')
 const { get, reduceObj, isObj } = require('@keg-hub/jsutils')
 const appConfig = {}
 
@@ -17,7 +17,7 @@ const validateTask = (key, task) => {
 
   let notValid
   // Ensure each custom task has the required task fields
-  TASK_REQURIED.map(field => {
+  TASK_REQUIRED.map(field => {
     notValid = !task[field] && { valid: false, message: `Task ${key} has a missing or invalid ${field} field!` }
   })
   

--- a/repos/keg-cli/src/utils/getters/getMutagenConfig.js
+++ b/repos/keg-cli/src/utils/getters/getMutagenConfig.js
@@ -46,7 +46,7 @@ const getMutagenConfig = async params => {
 
     const mutagenPath = __injected &&
       __injected.mutagenPath ||
-      getContainerConst(context, `ENV.KEG_MUTAGEN_PATH`)
+      getContainerConst(context, `ENV.KEG_MUTAGEN_FILE`)
 
     if(!mutagenPath) return deepMerge(overrides, parseOptions(options))
 

--- a/repos/keg-cli/src/utils/services/injectService.js
+++ b/repos/keg-cli/src/utils/services/injectService.js
@@ -107,7 +107,7 @@ const injectData = async ({ app, injectPath }, currentEnv, containerPaths) => {
     ENVS: {
       KEG_CONTEXT_PATH: injectPath,
       KEG_CONTAINER_PATH: containerPaths.containerPath,
-      KEG_MUTAGEN_PATH: containerPaths.mutagenPath,
+      KEG_MUTAGEN_FILE: containerPaths.mutagenPath,
       KEG_DOCKER_FILE: containerPaths.dockerPath,
       KEG_VALUES_FILE: containerPaths.valuesPath,
       KEG_COMPOSE_DEFAULT: containerPaths.composePath,


### PR DESCRIPTION
**Ticket**: [ZEN-463](https://jira.simpleviewtools.com/browse/ZEN-463)

[Semver-Status] minor

## Context

* These changes are part of a bigger ticket to update how docker images are managed. 

## Goal
* Fix spelling mistake
* Set proper name for ENV

## Updates

* `repos/keg-cli/containers/*`
  * Updated the name of the mutagen ENV
* `repos/keg-cli/src/constants/constants.js` && `repos/keg-cli/src/tasks/customTasks.js`
  * Fixed a spelling mistake
* 

## Testing
* Pull changes, and run tests
  * Run command `keg cli && keg pr 83 && keg cli test`
