### PR TITLE
fixed bug with missed keg prefix

### DIFF
--- a/repos/keg-components/src/hooks/useThemeTypeAsClass/useThemeTypeAsClass.js
+++ b/repos/keg-components/src/hooks/useThemeTypeAsClass/useThemeTypeAsClass.js
@@ -20,8 +20,7 @@ const useThemeType = (themeLoc, defClass) => {
     const surface = themeSplit.pop()
     const typeRef = themeSplit.pop()
     const surfaces = Object.keys(get(colors, 'surface', noOpObj))
-
-    return typeRef && surfaces.indexOf(surface)
+    return typeRef && surfaces.includes(surface)
       ? [ `${defClass}-${typeRef}`, surface ]
       : surface
         ? [`${defClass}-${surface}`]


### PR DESCRIPTION
## Context

* Checkbox items on the tap were greyed out when the `close` property was true, ultimately due to a bug in keg-components

## Goal

* fix this bug

## Updates

* `repos/keg-components/src/hooks/useThemeTypeAsClass/useThemeTypeAsClass.js`
  * ensured that it only includes the surface in the class array if it is a member of the valid surfaces

## Testing
* `keg components pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/keg-components:class-prefix-fix`
  * ensure everything looks right in storybook with checkboxes
* `keg evf pack run package=docker.pkg.github.com/simpleviewinc/keg-packages/tap:zen-423-pending-sessions`
  * open a group booking modal, and verify that the checkboxes do not look greyed-out
