### PR TITLE
Keg-CLI tap docker tasks

### DIFF
--- a/repos/keg-cli/src/tasks/docker/copy.js
+++ b/repos/keg-cli/src/tasks/docker/copy.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const docker = require('KegDocCli')
 const { Logger } = require('KegLog')
+const { get } = require('@keg-hub/jsutils')
 const { DOCKER } = require('KegConst/docker')
 const { buildContainerContext } = require('KegUtils/builders/buildContainerContext')
 const { throwRequired, generalError } = require('KegUtils/error')
@@ -56,7 +57,7 @@ const copy = async args => {
     log,
     local,
     remote,
-    container: id,
+    container: id || container || get(params, '__injected.container'),
     fromContainer: source === 'docker'
   })
 

--- a/repos/keg-cli/src/tasks/tap/docker/copy.js
+++ b/repos/keg-cli/src/tasks/tap/docker/copy.js
@@ -1,0 +1,62 @@
+const path = require('path')
+const { Logger } = require('KegLog')
+const { DOCKER } = require('KegConst/docker')
+const { runInternalTask } = require('KegUtils/task/runInternalTask')
+
+/**
+ * Copy files to and from a docker container
+ * @param {Object} args - arguments passed from the runTask method
+ * @param {string} args.command - Initial command being run
+ * @param {Array} args.options - arguments passed from the command line
+ * @param {Object} args.tasks - All registered tasks of the CLI
+ * @param {Object} globalConfig - Global config object for the keg-cli
+ *
+ * @returns {void}
+ */
+const copy = async args => {
+  // Connect to the tap image through internal task
+  return runInternalTask('tasks.docker.tasks.copy', {
+    ...args,
+    params: {
+      context: 'tap',
+      ...args.params,
+    },
+  })
+}
+
+module.exports = {
+  copy: {
+    name: 'copy',
+    alias: [ 'cp' ],
+    inject: true,
+    action: copy,
+    locationContext: DOCKER.LOCATION_CONTEXT.REPO,
+    description: `Copy files to and from a docker container`,
+    example: 'keg docker copy <options>',
+    options: {
+      source: {
+        alias: [ 'src',  ],
+        allowed: [ 'docker', 'host' ],
+        description: 'Source of the files to be copied.\nCopy from host: "local" || "host"\nCopy from docker: "docker" || "remote"',
+        default: 'docker'
+      },
+      local: {
+        alias: [ 'loc' ],
+        description: 'Local path to copy files to and from',
+        example: 'keg tap docker create --local ~/keg/keg-core',
+        enforced: true,
+      },
+      remote: {
+        alias: [ 'rem' ],
+        description: 'Remote path to copy files to and from',
+        example: 'keg tap docker --remote keg/keg-core',
+        enforced: true,
+      },
+      log: {
+        description: 'Log docker command',
+        example: 'keg tap docker copy --log',
+        default: false
+      },
+    }
+  }
+}

--- a/repos/keg-cli/src/tasks/tap/docker/copy.js
+++ b/repos/keg-cli/src/tasks/tap/docker/copy.js
@@ -43,13 +43,13 @@ module.exports = {
       local: {
         alias: [ 'loc' ],
         description: 'Local path to copy files to and from',
-        example: 'keg tap docker create --local ~/keg/keg-core',
+        example: 'keg tap docker copy --local ~/keg/keg-core',
         enforced: true,
       },
       remote: {
         alias: [ 'rem' ],
         description: 'Remote path to copy files to and from',
-        example: 'keg tap docker --remote keg/keg-core',
+        example: 'keg tap docker copy --remote keg/keg-core',
         enforced: true,
       },
       log: {

--- a/repos/keg-cli/src/tasks/tap/docker/docker.js
+++ b/repos/keg-cli/src/tasks/tap/docker/docker.js
@@ -1,0 +1,13 @@
+
+module.exports = {
+  docker: {
+    name: 'docker',
+    alias: [ 'doc' ],
+    description: 'Keg CLI tap docker specific tasks',
+    example: 'keg tap docker <command> <options>',
+    tasks: {
+      ...require('./exec'),
+      ...require('./copy'),
+    },
+  }
+}

--- a/repos/keg-cli/src/tasks/tap/docker/exec.js
+++ b/repos/keg-cli/src/tasks/tap/docker/exec.js
@@ -34,7 +34,7 @@ module.exports = {
     options: {
       cmd: {
         description: 'Docker container command to run. Default ( /bin/bash )',
-        example: 'keg tap exec --cmd test',
+        example: 'keg tap docker exec --cmd test',
         default: 'bash'
       },
       workdir: {

--- a/repos/keg-cli/src/tasks/tap/docker/exec.js
+++ b/repos/keg-cli/src/tasks/tap/docker/exec.js
@@ -1,0 +1,52 @@
+const { runInternalTask } = require('KegUtils/task/runInternalTask')
+const { DOCKER } = require('KegConst/docker')
+
+/**
+ * Attach to the running keg-tap container
+ * @param {Object} args - arguments passed from the runTask method
+ * @param {string} args.command - Initial command being run
+ * @param {Array} args.options - arguments passed from the command line
+ * @param {Object} args.tasks - All registered tasks of the CLI
+ * @param {Object} globalConfig - Global config object for the keg-cli
+ *
+ * @returns {void}
+ */
+const exec = args => {
+  // Connect to the tap image through internal task
+  return runInternalTask('tasks.docker.tasks.exec', {
+    ...args,
+    params: {
+      context: 'tap',
+      ...args.params,
+    },
+  })
+}
+
+module.exports = {
+  exec: {
+    name: 'exec',
+    alias: [ 'ex' ],
+    inject: true,
+    action: exec,
+    locationContext: DOCKER.LOCATION_CONTEXT.REPO,
+    description: `Run a command in a tap container`,
+    example: 'keg tap docker exec',
+    options: {
+      cmd: {
+        description: 'Docker container command to run. Default ( /bin/bash )',
+        example: 'keg tap exec --cmd test',
+        default: 'bash'
+      },
+      workdir: {
+        alias: [  'location', 'loc', 'dir', 'd' ],
+        description: 'Directory in the docker container where the command should be run',
+        example: 'keg tap docker exec --workdir /app',
+      },
+      options: {
+        alias: [ 'opts' ],
+        description: 'Extra docker exec command options',
+        default: '-it'
+      }
+    }
+  }
+}

--- a/repos/keg-cli/src/tasks/tap/docker/index.js
+++ b/repos/keg-cli/src/tasks/tap/docker/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./docker')

--- a/repos/keg-cli/src/tasks/tap/tap.js
+++ b/repos/keg-cli/src/tasks/tap/tap.js
@@ -30,6 +30,7 @@ module.exports = {
       ...require('./build'),
       ...require('./container'),
       ...require('./destroy'),
+      ...require('./docker'),
       ...require('./link'),
       ...require('./list'),
       ...require('./log'),


### PR DESCRIPTION
**Ticket**: [ZEN-456](https://jira.simpleviewtools.com/browse/ZEN-456)

[Semver-Status] minor

> ### Notes
> * This pr is dependent on two other PR's
>   * [tap-events-force](https://github.com/simpleviewinc/tap-events-force/pull/99)
>   * [keg-consumer](https://github.com/simpleviewinc/keg-test-consumer/pull/10)
> * Those PRs should be reviewed along with this one

## Context

* To add some tasks to the Keg-Cli for Taps

## Goal

* Add some docker tasks in the Keg-Cli for taps

## Updates

* `repos/keg-cli/src/tasks/docker/copy.js`
  * Minor update to ensure injected apps container can be used
* `repos/keg-cli/src/tasks/tap/docker/*`
  * Added some tap docker tasks
  * This ensure tap can properly use docker tasks not managed by docker-compose

## Testing

* Run the tests from [this keg-consumer PR](https://github.com/simpleviewinc/keg-test-consumer/pull/10)
  * All changes in this repo, are used within the PR's testing steps
