### PR TITLE
jsutils template

### DIFF
--- a/repos/jsutils/src/string/__tests__/template.js
+++ b/repos/jsutils/src/string/__tests__/template.js
@@ -13,6 +13,15 @@ describe('template', () => {
 
   })
 
+  it('should replace correct value on edge case: 2 closing brackets with content in between the last bracket ', () => {
+
+    const template = '${ who } don`t replace me}} in ${ where }'
+    const data = { who: 'goats', where: 'boats' }
+
+    expect(Str.template(template, data)).toEqual("goats don`t replace me}} in boats")
+
+  })
+
   it('should use the fallback when the value does not exist', () => {
 
     const template = '${ who } in ${ where }'

--- a/repos/jsutils/src/string/template.js
+++ b/repos/jsutils/src/string/template.js
@@ -18,7 +18,7 @@ import { isStr } from './isStr'
  */
 export const template = (tempStr, data, fallback='') => {
   data = isColl(data) && data || {}
-  const regex = template.regex || /\${([^{]+[^}])}/g
+  const regex = template.regex || /\${(.*?)\}/g
 
   return isStr(tempStr)
     ? tempStr.replace(regex, (match, exact) => {


### PR DESCRIPTION


## Context

* I'm trying to utilize the `template` jsutils in `keg-herkin` and noticed an edge case
* There exists an edge case where if:
   * there exists 2 closing brackets `}` AND there is content in between them, it will include it in the replace. which we don't want

* example: `{ ${where} some content }`
   * we expect: `${where}` to be replaced. but instead it replaces `${where} some content }`
   * [image](https://user-images.githubusercontent.com/3317835/105554342-5edfc200-5cc4-11eb-8f6e-5e54c52d1c3e.png)

* edge case scenario: *it's currently not replacing `${url}` properly*
```js
test('${name}', async () => {
  await qawolf.create('${url}')
})
```

## Goal

- update regex on template util to cover this edge case
- ensure other tests still passes

## Updates

* `repos/jsutils/src/string/__tests__/template.js`
   * added unit test for edge case

* `repos/jsutils/src/string/template.js`
   * updated regex

## Testing

* pull this branch
* run the jsutils unit test
   * `keg jsutils && yarn test`


