### PR TITLE
Zen 463 image from updates

### DIFF
--- a/repos/re-theme/container/Dockerfile
+++ b/repos/re-theme/container/Dockerfile
@@ -1,88 +1,39 @@
-# Allows overwriting where the base image is pulled from
-# Must come before the FROM directive
+# Path of the tap within the docker container
+ARG DOC_APP_PATH
+
+# Setup the taps image FROM in the global state
+# Must come before the FROM directive to is can be accessed
 ARG KEG_NODE_VERSION
-ARG GIT_STAGE_IMAGE_FROM=node:$KEG_NODE_VERSION
-ARG KEG_IMAGE_FROM=keg-base:latest
-FROM $KEG_IMAGE_FROM as builder
+ARG NODE_IMAGE_FROM=node:$KEG_NODE_VERSION
 
-WORKDIR /
+# Add a FROM for the tap-base image to we can copy content from it
+ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
+FROM $KEG_BASE_IMAGE as tap-base
 
-# Add npm-run-all globally
-RUN yarn global add npm-run-all
+# Get the git keg-hub url and branch to pull down
+ARG GIT_HUB_URL=https://github.com/simpleviewinc/keg-hub.git
+ARG GIT_HUB_BRANCH=develop
 
-# Should we use the local copy of the tap repo when building
-ARG KEG_COPY_LOCAL
+ENV DOC_APP_PATH=$DOC_APP_PATH
 
-# Path of the app within the docker container
-ARG DOC_APP_PATH=/keg/tap
-
-# Copy over the app to a temp directory
-COPY . /keg-temp/
-
-# Update the build steps git config to include the key
-# Pull down the tap locally if a git tap url exists
-# Otherwise copy over the local version from keg-temp
-RUN git config --global url.https://$PUBLIC_GIT_KEY@github.com/.insteadOf https://github.com/; \
-    if [ -z "$KEG_COPY_LOCAL" ] && [ "$GIT_APP_URL" != "INITIAL" ]; then \
-      git clone $GIT_APP_URL $DOC_APP_PATH; \
-    else \
-      cp -R /keg-temp/ $DOC_APP_PATH; \
-    fi; \
-    rm -rf /keg-temp
-
-# Copy over the package.json, and yarn.lock files
-COPY package.json $DOC_APP_PATH/package.json
-COPY *.lock $DOC_APP_PATH/
-
-# Install the dependecies with yarn setup, then remove the .npmrc
-RUN cd $DOC_APP_PATH; \
-    yarn install --ignore-engines; \
-    yarn cache clean; \
-    rm -f .npmrc
-
-
-# ------- New Build Stage ------- #
-
-# Use a multi stage build for security
-# This is so PUBLIC_GIT_KEY is not accessable in the final image
-FROM $GIT_STAGE_IMAGE_FROM as gitBuilder
-WORKDIR /
-
-
-# Path of the app within the docker container
-ARG DOC_APP_PATH=${DOC_APP_PATH:-/keg/tap}
-ARG KEG_PROXY_PORT=${KEG_PROXY_PORT:-5000}
-
-# Get the ip of docker-machine from the ARG, so we can set it as an ENV
-ARG KEG_DOCKER_IP
-
-# Used by react native builder to set the ip address, other wise 
-# Will use the ip address of the docker container.
-ENV REACT_NATIVE_PACKAGER_HOSTNAME $KEG_DOCKER_IP
-
-# Install git for the new stage
-RUN apk add --no-cache git bash sudo; \
-    echo fs.inotify.max_user_watches=1048576 | sudo tee -a /etc/sysctl.conf; \
-    sudo sysctl -p; \
-    git config --global url.https://$PUBLIC_GIT_KEY@github.com/.insteadOf https://github.com/; \
-    rm -rf /var/cache/apk/*; \
-    /bin/sed -i '1s|.*|root:x:0:0:root:/root:/bin/bash|g' /etc/passwd
-
-# Copy over the globally installed modules from above
-COPY --from=builder /usr/local/share/.config/yarn /usr/local/share/.config/yarn
-# Add yarn's global bin to PATH
-ENV PATH=$PATH:/usr/local/share/.config/yarn/global/node_modules/.bin
-
-# Copy over the cloned app
-COPY --from=builder $DOC_APP_PATH $DOC_APP_PATH
-
-EXPOSE $KEG_PROXY_PORT
 # Set the current directory to tap repo
 WORKDIR $DOC_APP_PATH
 
-SHELL [ "/bin/bash", "-c" ]
+# Pull down the keg-hub repo from github
+# Because retheme is inside keg-hub, clone keg-hub
+# Then copy over retheme to the correct directory
+# Install all deps, and copy jsutils from keg-core to get the up-to-date verison
+# Finally remove the keg-hub repos
+RUN git clone --single-branch --branch $GIT_HUB_BRANCH $GIT_HUB_URL /keg-hub-clone; \
+    cp -R /keg-hub-clone/repos/re-theme/. $DOC_APP_PATH/; \
+    rm -rf /keg-hub-clone; \
+    cd $DOC_APP_PATH; \
+    yarn install --pure-lockfile; \
+    yarn cache clean; \
+    cp -R /keg-hub/repos/keg-core/node_modules/@keg-hub/jsutils/build/. $DOC_APP_PATH/node_modules/@keg-hub/jsutils/build/; \
+    rm -rf /keg-hub
 
-SHELL [ "/bin/bash" ]
+EXPOSE $KEG_PROXY_PORT
 
 # Run the start script
 CMD [ "/bin/bash", "container/run.sh" ]

--- a/repos/re-theme/container/docker-compose.yml
+++ b/repos/re-theme/container/docker-compose.yml
@@ -1,23 +1,9 @@
 version: "3.8"
 services:
   retheme:
-    image: ${IMAGE}
-    tty: true
-    stdin_open: true
-    privileged: true
-    volumes:
-      - ${CLI_PATH}:${DOC_CLI_PATH}
-    build:
-      context: ${KEG_CONTEXT_PATH}
-      dockerfile: ${KEG_DOCKER_FILE}
-      args:
-        - DOC_APP_PATH
-        - KEG_PROXY_PORT
-        - ENV
-        - NODE_ENV
-    container_name: ${CONTAINER_NAME}
     environment:
       - DOC_APP_PATH
+      - DOC_JSUTILS_PATH
       - KEG_PROXY_PORT
       - ENV
       - KEG_EXEC_CMD

--- a/repos/re-theme/container/run.sh
+++ b/repos/re-theme/container/run.sh
@@ -2,53 +2,6 @@
 
 export SUPPRESS_SUPPORT=1
 
-APP_PATH=/keg/tap
-
-# If DOC_APP_PATH env is passed override the default app path
-if [[ "$DOC_APP_PATH" ]]; then
-  APP_PATH="$DOC_APP_PATH"
-fi
-
-# Helper to print a message to the terminal
-keg_message(){
-  echo $"[ KEG-CLI ] $1" >&2
-  return
-}
-
-# Runs yarn install at run time
-# Use when adding extra node_modules to keg-core without rebuilding
-keg_run_tap_yarn_setup(){
-
-  # Check if $KEG_NM_INSTALL exist, if it doesn't, then return
-  if [[ -z "$KEG_NM_INSTALL" ]]; then
-    return
-  fi
-
-  # Navigate to the app directory, and run the yarn install here
-  cd $APP_PATH
-
-  keg_message "Running yarn setup for app..."
-  yarn setup
-
-}
-
-
-# Runs a yarn command from the package.json
-keg_run_the_tap(){
-
-  cd $APP_PATH
-
-  # Check if no exect command exists, or if it's set to web
-  # Then default it to run the re-theme app
-  if [[ -z "$KEG_EXEC_CMD" || "$KEG_EXEC_CMD" == 'web' ]]; then
-    KEG_EXEC_CMD="sb"
-  fi
-
-  keg_message "Running command 'yarn $KEG_EXEC_CMD'"
-  yarn $KEG_EXEC_CMD
-
-}
-
 # If the no KEG_DOCKER_EXEC env is set, just sleep forever
 # This is to keep our container running forever
 if [[ -z "$KEG_DOCKER_EXEC" ]]; then
@@ -57,12 +10,24 @@ if [[ -z "$KEG_DOCKER_EXEC" ]]; then
 
 else
 
-  # Run yarn setup for any extra node_modules to be installed
-  keg_run_tap_yarn_setup
+  # Ensure the DOC_APP_PATH is set
+  if [[ -z "$DOC_APP_PATH" ]]; then
+    DOC_APP_PATH=/keg/tap
+  fi
 
-  # Start the retheme app
-  keg_run_the_tap "$@"
+  # cd into the tap repo
+  cd $DOC_APP_PATH
+
+  # Check if no exect command exists, or if it's set to web
+  # Then default it to run the re-theme app
+  if [[ -z "$KEG_EXEC_CMD" || "$KEG_EXEC_CMD" == 'web' ]]; then
+    KEG_EXEC_CMD="sb"
+  fi
+
+  # Start the tap instance
+  echo $"[ KEG-CLI ] Running command 'yarn $KEG_EXEC_CMD'" >&2
+  yarn $KEG_EXEC_CMD
+
 fi
-
 
 

--- a/repos/re-theme/container/run.sh
+++ b/repos/re-theme/container/run.sh
@@ -29,5 +29,3 @@ else
   yarn $KEG_EXEC_CMD
 
 fi
-
-

--- a/repos/re-theme/container/values.yml
+++ b/repos/re-theme/container/values.yml
@@ -7,22 +7,22 @@ env:
   # Example command to link the app => `keg tap link kee`
   KEG_DOCKER_FILE: "{{ cli.taps.links.retheme }}/container/Dockerfile"
   KEG_VALUES_FILE: "{{ cli.taps.links.retheme }}/container/values.yml"
+  KEG_MUTAGEN_FILE: "{{ cli.taps.links.retheme }}/container/values.yml"
   KEG_COMPOSE_DEFAULT: "{{ cli.taps.links.retheme }}/container/docker-compose.yml"
 
   # The KEG_CONTEXT_PATH env should be the location of the external app being run
   KEG_CONTEXT_PATH: "{{ cli.taps.links.retheme }}"
 
+  # Image to use when building retheme
+  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
 
-  # --- GIT ENV CONTEXT --- #
-
-  GIT_RETHEME_URL: "{{ cli.git.orgUrl }}/re-theme.git"
-
+  # Image to use when running retheme
+  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/retheme:master
 
   # --- DOCKER ENV CONTEXT --- #
 
   # Default location of the app in the docker container
   DOC_APP_PATH: /keg/tap
-  DOC_RETHEME_PATH: /keg/tap
   DOC_JSUTILS_PATH: /keg/tap/node_modules/@keg-hub/jsutils
 
   # Default port of the app to expose from the container
@@ -35,5 +35,5 @@ env:
   # IMAGE and CONTAINER_NAME should be the same
   IMAGE: retheme
   CONTAINER_NAME: retheme
-  VERSION: "0.0.1"
+  VERSION: 1.0.0
   CHOKIDAR_USEPOLLING: 1

--- a/repos/re-theme/container/values.yml
+++ b/repos/re-theme/container/values.yml
@@ -5,13 +5,13 @@ env:
   # Set the paths to the linked external app
   # The app should be linked to the keg-cli with `kee`
   # Example command to link the app => `keg tap link kee`
-  KEG_DOCKER_FILE: "{{ cli.taps.links.retheme }}/container/Dockerfile"
-  KEG_VALUES_FILE: "{{ cli.taps.links.retheme }}/container/values.yml"
-  KEG_MUTAGEN_FILE: "{{ cli.taps.links.retheme }}/container/values.yml"
-  KEG_COMPOSE_DEFAULT: "{{ cli.taps.links.retheme }}/container/docker-compose.yml"
+  KEG_DOCKER_FILE: "{{ cli.taps.retheme.path }}/container/Dockerfile"
+  KEG_VALUES_FILE: "{{ cli.taps.retheme.path }}/container/values.yml"
+  KEG_MUTAGEN_FILE: "{{ cli.taps.retheme.path }}/container/values.yml"
+  KEG_COMPOSE_DEFAULT: "{{ cli.taps.retheme.path }}/container/docker-compose.yml"
 
   # The KEG_CONTEXT_PATH env should be the location of the external app being run
-  KEG_CONTEXT_PATH: "{{ cli.taps.links.retheme }}"
+  KEG_CONTEXT_PATH: "{{ cli.taps.retheme.path }}"
 
   # Image to use when building retheme
   KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master


### PR DESCRIPTION
**Ticket**: [ZEN-532](https://jira.simpleviewtools.com/browse/ZEN-532)
> Depends on this keg-cli PR: https://github.com/simpleviewinc/keg-cli/pull/31

## Context

* Because of the new `image from updates`, we need to update the contents in the `re-theme/container` to work with the new workflow

## Goal
* To ensure you can still run the same commands when working in a container
* Updating the containers folder to work with the new image workflow

## Updates

* `re-theme/container/*`
   * Updated the container files to work with the Keg-CLI's `Image-From` updates

## Testing

### Setup
* Pull this branch locally => `keg hub && keg pr 131`
* Ensure your `keg-cli` is on branch `ZEN-463-push-pull-tasks`
* Ensure you don't have any retheme images locally

### Test 1
* In the terminal run `keg retheme start`
   * It should pull the evf image from `ghcr.io/simpleviewinc/retheme:master`
   * It should then start the retheme tap
* Navigate to http://retheme-zen-463-image-from-updates.local.kegdev.xyz/
   * Ensure the Tap loads as expected

### Test 2
* Make changes to your local `retheme` || `jsutils` repo
* Open a new terminal tab and run `keg retheme sync jsutils:install:build`
  * It should install and sync local jsutils into the docker container
  * Ensure the changes are reflected in the app
