### PR TITLE
ZEN-543: Develop Tag

### DIFF
--- a/repos/re-theme/container/Dockerfile
+++ b/repos/re-theme/container/Dockerfile
@@ -7,7 +7,7 @@ ARG KEG_NODE_VERSION
 ARG NODE_IMAGE_FROM=node:$KEG_NODE_VERSION
 
 # Add a FROM for the tap-base image to we can copy content from it
-ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:master
+ARG KEG_BASE_IMAGE=ghcr.io/simpleviewinc/tap:develop
 FROM $KEG_BASE_IMAGE as tap-base
 
 # Get the git keg-hub url and branch to pull down

--- a/repos/re-theme/container/values.yml
+++ b/repos/re-theme/container/values.yml
@@ -14,10 +14,10 @@ env:
   KEG_CONTEXT_PATH: "{{ cli.taps.retheme.path }}"
 
   # Image to use when building retheme
-  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:master
+  KEG_BASE_IMAGE: ghcr.io/simpleviewinc/tap:develop
 
   # Image to use when running retheme
-  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/retheme:master
+  KEG_IMAGE_FROM: ghcr.io/simpleviewinc/retheme:develop
 
   # --- DOCKER ENV CONTEXT --- #
 


### PR DESCRIPTION
**Ticket**: [ZEN-543](https://jira.simpleviewtools.com/browse/ZEN-543)

## Context

* As part of ZEN-543, we determined we should change the default docker image tag from "master" to "develop" for clarity and consistency with the git branches

## Goal

* Update all references of the old "master" to "develop"

## Updates
* `repos/re-theme/container/Dockerfile` && `repos/re-theme/container/values.yml`
  * updated `master` references to `develop`
* The remaining repo updates are in `keg-cli`

## Testing
* Follow testing in keg-cli pr: https://github.com/simpleviewinc/keg-cli/pull/59

