### PR TITLE
JSUtils v8.6.0

### DIFF
--- a/repos/jsutils/package.json
+++ b/repos/jsutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keg-hub/jsutils",
-  "version": "8.4.0",
+  "version": "8.6.0",
   "description": "Keg common javascript utils",
   "main": "build/umd/index.js",
   "module": "build/esm/index.js",


### PR DESCRIPTION
Releasing jsutils v8.6 to get access to `mapFind`