### PR TITLE
fix(resolver): Remove app.js as an allowed config file

### DIFF
--- a/repos/tap-resolver/src/tap/tapConstants.js
+++ b/repos/tap-resolver/src/tap/tapConstants.js
@@ -15,10 +15,8 @@ module.exports = deepFreeze({
     'tap.config.json',
     'tap.json',
     'app.config.js',
-    'app.js',
     'app.config.json',
     'app.json',
-    'package.json',
   ],
   /**
    * Constants added to temp config files for reference


### PR DESCRIPTION

## Context
* This is a major breaking change
* When node.js runs on a mac, the casing of a file is ignored. So `app` and `App`  are considered the same
* This causes issues when running the keg-core tests on a mac machine.
  * Keg-core has a `app.json` file and a `App.js` file
  * When tap-resolver tries to load the config, it loads the `App.js` file instead of the `app.json` file  

## Goal
* Remove ability to set `app.js` and `package.json` as an option for a taps config
* Allow keg-core tests to pass on a mac machine

## Updates

* `repos/tap-resolver/src/tap/tapConstants.js`
  * Removed `app.js` and `package.json` from `tapConstants.configNames`

## Testing

### Setup
* Pull this PR =>  `keg pr 194`
* Switch to tap-resolver => `keg resolver`
* Install deps => `yarn install`
* Switch to keg-core => `keg core`
* Install deps => `yarn install`
* Copy these code changes from tap-resolver into keg-core
  *  `rm -rf ~/keg-hub/repos/keg-core/node_modules/@keg-hub/tap-resolver`
  *  `cp -R ~/keg-hub/repos/tap-resolver ~/keg-hub/repos/keg-core/node_modules/@keg-hub/tap-resolver` 

### Test 1
* Run the tests in keg-core 
  * `keg core`
  * `yarn test`
* Ensure all tests pass