### PR TITLE
ZEN-649 : Only display header if title is not empty

### DIFF
--- a/repos/keg-components/src/components/header/itemHeader/itemHeader.js
+++ b/repos/keg-components/src/components/header/itemHeader/itemHeader.js
@@ -149,15 +149,17 @@ const Center = props => {
       className='keg-header-center'
       style={styles.main}
     >
-      { (children && renderFromType(children, {}, null)) || (
-        <H5
-          className='keg-header-center-title'
-          ellipsis={ellipsis}
-          style={styles.content.title}
-        >
-          { title }
-        </H5>
-      ) }
+      { (children && renderFromType(children, {}, null)) || 
+        //Don't render header element if title is empty since it causes issues with Accessibility standards
+        ( title && (
+          <H5
+            className='keg-header-center-title'
+            ellipsis={ellipsis}
+            style={styles.content.title}
+          >
+            { title }
+          </H5>
+        )) }
     </View>
   )
 }


### PR DESCRIPTION
**Ticket**: https://jira.simpleviewtools.com/browse/ZEN-649

## Context

* Updates to improve WCAG Accessibility Standards

## Goal

* Ensure there are no empty header elements the session title

## Updates

* keg-components/src/components/header/itemHeader/itemHeader.js
  * Added a check for empty title , and if it is , do not render the H5 element

## Testing

* Setup
  * Run the command => keg evf pack run evf:zen-649-accessibilitystandards-v2
  * Navigate to http://evf-zen-649-accessibilitystandards-v2.local.keghub.io/

* Testing header
  * Open the dev console
  * click on the center element of the time slot.
  * Ensure it no longer has a child H5 element
