### PR TITLE
Update SvgIcon to support other elements than just Path

### DIFF
--- a/repos/keg-components/src/components/svgIcon/svgIcon.examples.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.examples.js
@@ -75,3 +75,22 @@ export const Loading = props => {
     </StoryWrap>
   )
 }
+
+export const WithChildren = () => {
+  return (
+    <StoryWrap style={wrapStyles}>
+      <SvgIcon
+        viewBox='0 0 20 20'
+        size={20}
+        className='keg-svg-children'
+      >
+        <SvgIcon.Circle 
+          cx='10'
+          cy='10'
+          r='10'
+          fill='#356C99'
+        />
+      </SvgIcon>
+    </StoryWrap>
+  )
+}

--- a/repos/keg-components/src/components/svgIcon/svgIcon.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.js
@@ -1,4 +1,3 @@
-// import { SvgIcon as KegSvgIcon } from './svgIcon.native'
 import * as NativeSvg from './svgIcon.native'
 import { StyleInjector } from '@keg-hub/re-theme/styleInjector'
 

--- a/repos/keg-components/src/components/svgIcon/svgIcon.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.js
@@ -1,5 +1,8 @@
-import { SvgIcon as KegSvgIcon } from './svgIcon.native'
+// import { SvgIcon as KegSvgIcon } from './svgIcon.native'
+import * as NativeSvg from './svgIcon.native'
 import { StyleInjector } from '@keg-hub/re-theme/styleInjector'
+
+const { SvgIcon: KegSvgIcon, ...svgElements } = NativeSvg
 
 /**
  * SvgIcon
@@ -13,6 +16,10 @@ export const SvgIcon = StyleInjector(KegSvgIcon, {
   displayName: 'SvgIcon',
   className: 'keg-svg-icon',
 })
+
+// add all the react-native-svg exports, like Circle, so that clients
+// can use them as children (e.g. SvgIcon.Circle)
+Object.assign(SvgIcon, svgElements)
 
 SvgIcon.propTypes = {
   ...KegSvgIcon.propTypes,

--- a/repos/keg-components/src/components/svgIcon/svgIcon.native.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.native.js
@@ -100,7 +100,7 @@ const useClassName = className => {
  *                              - Used as the stroke color when no stroke prop is passed
  *                              - Used as the fill color when no fill prop is passed
  * @param {string=} props.clipRule - Svg rule for clipping
- * @param {string=} props.delta - Path definition for the Svg Component
+ * @param {string=} props.delta - Path definition for the Svg Component. If omitted, no Path element is rendered.
  * @param {string=} props.fill - Fill color of the path element
  * @param {string=} props.fillRule - Svg rule for the fill attribute
  * @param {string=} props.size - Size of the Svg Component

--- a/repos/keg-components/src/components/svgIcon/svgIcon.native.js
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.native.js
@@ -131,6 +131,7 @@ export const SvgIcon = React.forwardRef((props, ref) => {
     svgFill,
     viewBox,
     width,
+    children,
     ...attrs
   } = props
 
@@ -149,16 +150,19 @@ export const SvgIcon = React.forwardRef((props, ref) => {
       viewBox={viewBox}
       style={svgStyles}
     >
-      <Path
-        clipRule={clipRule}
-        d={delta}
-        fill={colorStyle.fill}
-        fillRule={fillRule}
-        stroke={colorStyle.stroke}
-        strokeWidth={strokeWidth}
-        strokeLinecap={strokeLinecap}
-        strokeLinejoin={strokeLinejoin}
-      />
+      { delta && 
+          <Path
+            clipRule={clipRule}
+            d={delta}
+            fill={colorStyle.fill}
+            fillRule={fillRule}
+            stroke={colorStyle.stroke}
+            strokeWidth={strokeWidth}
+            strokeLinecap={strokeLinecap}
+            strokeLinejoin={strokeLinejoin}
+          />
+      }
+      { children }
     </Svg>
   )
 })
@@ -177,3 +181,5 @@ SvgIcon.propTypes = {
   svgFill: PropTypes.string,
   viewBox: PropTypes.string,
 }
+
+export * from 'react-native-svg'

--- a/repos/keg-components/src/components/svgIcon/svgIcon.stories.mdx
+++ b/repos/keg-components/src/components/svgIcon/svgIcon.stories.mdx
@@ -4,7 +4,7 @@ import { Story, Meta, Preview, Props, Description } from '@storybook/addon-docs'
 
 import { SvgIcon } from './svgIcon'
 import { SvgIcon as SvgIconNative } from './svgIcon.native'
-import {Basic, Loading} from './svgIcon.examples.js'
+import {Basic, Loading, WithChildren } from './svgIcon.examples.js'
 
 <Meta title="Components/Display/SvgIcon" component={SvgIcon}/>
 
@@ -28,6 +28,15 @@ Utilizes [react-native-svg](https://github.com/react-native-svg/react-native-svg
 <Preview>
   <Story name="Loading">
     <Loading />
+  </Story>
+</Preview>
+
+<br/>
+
+### With Children
+<Preview>
+  <Story name="With Children">
+    <WithChildren />
   </Story>
 </Preview>
 


### PR DESCRIPTION
**Ticket**: [ZEN-632](https://jira.simpleviewtools.com/browse/ZEN-632)

## Goal

* ZEN-632 requires that I use the `Circle` svg element, but it is not supported by our `SvgIcon` wrapper component.
* We should export all the other elements of `react-native-svg` to allow consumers to use them, like:
```javascript
      <SvgIcon
        viewBox='0 0 20 20'
        size={20}
        className='keg-svg-children'
      >
        <SvgIcon.Circle 
          cx='10'
          cy='10'
          r='10'
          fill='#356C99'
        />
      </SvgIcon>
```

## Updates
* `repos/keg-components/src/components/svgIcon/svgIcon.examples.js` & `repos/keg-components/src/components/svgIcon/svgIcon.stories.mdx`
  * added an example
* `repos/keg-components/src/components/svgIcon/svgIcon.js`
  * adding the other elements to the `SvgIcon` export (e.g. `SvgIcon.Circle`)
* `repos/keg-components/src/components/svgIcon/svgIcon.native.js`
  * added children support
  * changed `<Path ...` to only render if `delta` prop is passed

## Testing
* `keg components pack run package=keg-components:svg-exports`
* Navigate to the `SvgIcon>With Children` story
* Verify that the circle icon renders
