### PR TITLE
Build hotfix

### DIFF
--- a/repos/keg-components/build/esm/index.mjs
+++ b/repos/keg-components/build/esm/index.mjs
@@ -1,1 +1,1 @@
-export * from './web/index.mjs'
+export * from './web/index.js'

--- a/repos/keg-components/build/esm/index.native.mjs
+++ b/repos/keg-components/build/esm/index.native.mjs
@@ -1,1 +1,1 @@
-export * from './native/index.mjs'
+export * from './native/index.js'

--- a/repos/keg-components/package.json
+++ b/repos/keg-components/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@keg-hub/keg-components",
-  "version": "9.5.0",
+  "name": "@old-keg-hub/keg-components",
+  "version": "9.5.1",
   "main": "build/cjs",
   "module": "build/esm",
   "publishConfig": {

--- a/repos/keg-core/README.md
+++ b/repos/keg-core/README.md
@@ -1,5 +1,7 @@
 # Keg Core
 
+> NOTE: This repository is deprecated and unmaintained. Please use [@keg-hub/keg-hub](https://github.com/keg-hub/keg-hub) instead.
+
 ## Overview
 
 The keg is a platform for developing cross-platform react apps.

--- a/repos/keg-core/core/base/assets/index.js
+++ b/repos/keg-core/core/base/assets/index.js
@@ -4,5 +4,5 @@
 // ********************************* WARNING *********************************
 
 export const assets = {
-  ['clientLogo']: require('/home/runner/work/keg-hub/keg-hub/repos/keg-core/core/base/assets/clientLogo.jpg')
+  ['clientLogo']: require('/Users/michael.carolin/keg-hub/repos/keg-core/core/base/assets/clientLogo.jpg')
 }

--- a/repos/keg-core/core/base/components/kegComponents.js
+++ b/repos/keg-core/core/base/components/kegComponents.js
@@ -1,1 +1,1 @@
-export * from '@keg-hub/keg-components'
+export * from '@old-keg-hub/keg-components'

--- a/repos/keg-core/core/base/components/meta/versionDisplay.js
+++ b/repos/keg-core/core/base/components/meta/versionDisplay.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { View, Link } from '@keg-hub/keg-components'
+import { View, Link } from '@old-keg-hub/keg-components'
 
 /**
  * @param {string} homepage

--- a/repos/keg-core/core/base/theme/kegComponentsTheme.js
+++ b/repos/keg-core/core/base/theme/kegComponentsTheme.js
@@ -1,1 +1,1 @@
-export { theme as kegComponentsTheme } from '@keg-hub/keg-components'
+export { theme as kegComponentsTheme } from '@old-keg-hub/keg-components'

--- a/repos/keg-core/core/configs/webpack.config.js
+++ b/repos/keg-core/core/configs/webpack.config.js
@@ -23,7 +23,7 @@ const resolveCoreAlias = {
     '@keg-hub/re-theme/build/esm/web/styleParser.js',
   '@keg-hub/re-theme/styleInjector':
     '@keg-hub/re-theme/build/esm/web/styleInjector.js',
-  '@keg-hub/keg-components': '@keg-hub/keg-components/build/esm/web',
+  '@old-keg-hub/keg-components': '@old-keg-hub/keg-components/build/esm/web',
 }
 
 /**

--- a/repos/keg-core/package.json
+++ b/repos/keg-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keg-hub/keg-core",
   "main": "node_modules/expo/AppEntry.js",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "publishConfig": {
     "access": "public"
   },
@@ -60,7 +60,7 @@
     "@babel/runtime": "7.15.3",
     "@expo/webpack-config": "0.14.0",
     "@keg-hub/jsutils": "8.7.0",
-    "@keg-hub/keg-components": "9.5.0",
+    "@keg-hub/keg-components": "9.5.1",
     "@keg-hub/re-theme": "9.5.0",
     "@keg-hub/tap-resolver": "9.0.0",
     "@testing-library/react-hooks": "7.0.1",
@@ -110,7 +110,7 @@
   },
   "resolutions": {
     "@keg-hub/jsutils": "8.7.0",
-    "@keg-hub/keg-components": "9.5.0",
+    "@keg-hub/keg-components": "9.5.1",
     "@keg-hub/re-theme": "9.5.0",
     "@keg-hub/tap-resolver": "8.0.0",
     "react": "17.0.2",

--- a/repos/keg-core/package.json
+++ b/repos/keg-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@keg-hub/keg-core",
+  "name": "@old-keg-hub/keg-core",
   "main": "node_modules/expo/AppEntry.js",
   "version": "9.5.1",
   "publishConfig": {
@@ -60,7 +60,7 @@
     "@babel/runtime": "7.15.3",
     "@expo/webpack-config": "0.14.0",
     "@keg-hub/jsutils": "8.7.0",
-    "@keg-hub/keg-components": "9.5.1",
+    "@old-keg-hub/keg-components": "9.5.1",
     "@keg-hub/re-theme": "9.5.0",
     "@keg-hub/tap-resolver": "9.0.0",
     "@testing-library/react-hooks": "7.0.1",
@@ -110,7 +110,7 @@
   },
   "resolutions": {
     "@keg-hub/jsutils": "8.7.0",
-    "@keg-hub/keg-components": "9.5.1",
+    "@old-keg-hub/keg-components": "9.5.1",
     "@keg-hub/re-theme": "9.5.0",
     "@keg-hub/tap-resolver": "8.0.0",
     "react": "17.0.2",

--- a/repos/keg-core/yarn.lock
+++ b/repos/keg-core/yarn.lock
@@ -1786,11 +1786,6 @@
   resolved "https://registry.yarnpkg.com/@keg-hub/jsutils/-/jsutils-8.7.0.tgz#ee05638b2b6df0c251cdf28634694ac198f9211f"
   integrity sha512-ipbvP/yDZIYnneG8bAFjBGwR7QOGT3U5Dp5Y6Y1kPHbe6LFEoKhBVt6x9f5MavluGgofjulNpmwDcomCl+zbeA==
 
-"@keg-hub/keg-components@9.5.0":
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@keg-hub/keg-components/-/keg-components-9.5.0.tgz#c3678bdbc5bbb26844989c6fb2fb95a3492e45f0"
-  integrity sha512-BzL6iYnPnTDGojRpb3kqDeZY7yVmvb0Mnm//vNCTbyrgDf9/SA4kTi87q21mmRvwLqhdJh0STRgfbjFISZDpng==
-
 "@keg-hub/re-theme@9.5.0":
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/@keg-hub/re-theme/-/re-theme-9.5.0.tgz#864742469caeacd9f4e8f35d4534db68a7411f3d"
@@ -1834,6 +1829,11 @@
   dependencies:
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
+
+"@old-keg-hub/keg-components@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/@old-keg-hub/keg-components/-/keg-components-9.5.1.tgz#39901ad4456ca90a632aa710c438c7497e63c8c5"
+  integrity sha512-ObBgzkfRFL87riUYdfLDr7RvB/L08FgU3puA5dLJp39+pw6VNnmBwNOCcm5pIaFqVMz2shhuoDdzeUZzyIrwHQ==
 
 "@react-native-community/cli-debugger-ui@^5.0.1":
   version "5.0.1"

--- a/scripts/ci/buildChangedRepos.sh
+++ b/scripts/ci/buildChangedRepos.sh
@@ -154,12 +154,12 @@ keg_build_core(){
     fi
 
     # Remove, and copy keg-components latest build into keg-core
-    if [[ -d "$KEG_CORE_PATH/node_modules/@keg-hub/keg-components/build" ]]; then
+    if [[ -d "$KEG_CORE_PATH/node_modules/@old-keg-hub/keg-components/build" ]]; then
 
       echo "::debug::Repo keg-components was changed, copying into keg-core..."
 
-      rm -rf $KEG_CORE_PATH/node_modules/@keg-hub/keg-components/build
-      cp -R $KEG_COMPS_PATH/build $KEG_CORE_PATH/node_modules/@keg-hub/keg-components/build
+      rm -rf $KEG_CORE_PATH/node_modules/@old-keg-hub/keg-components/build
+      cp -R $KEG_COMPS_PATH/build $KEG_CORE_PATH/node_modules/@old-keg-hub/keg-components/build
     fi
 
     # Remove, and copy tap-resolver latest build into keg-core

--- a/taps/tap-release-client/container/mutagen.yml
+++ b/taps/tap-release-client/container/mutagen.yml
@@ -59,17 +59,17 @@ actions:
         - yarn dev
   components:
     install:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      location: /keg/tap/node_modules/keg-core/node_modules/@old-keg-hub/keg-components
       privileged: true
       cmds:
         - yarn install
     build:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      location: /keg/tap/node_modules/keg-core/node_modules/@old-keg-hub/keg-components
       privileged: true
       cmds:
         - yarn build
     start:
-      location: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+      location: /keg/tap/node_modules/keg-core/node_modules/@old-keg-hub/keg-components
       privileged: true
       detach: true
       cmds:

--- a/taps/tap-release-client/container/values.yml
+++ b/taps/tap-release-client/container/values.yml
@@ -17,7 +17,7 @@ env:
   # Default location of the app in the docker container
   DOC_APP_PATH: /keg/tap
   DOC_CORE_PATH: /keg/tap/node_modules/keg-core
-  DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/keg-components
+  DOC_COMPONENTS_PATH: /keg/tap/node_modules/keg-core/node_modules/@old-keg-hub/keg-components
   DOC_RETHEME_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/re-theme
   DOC_RESOLVER_PATH: /keg/tap/node_modules/keg-core/node_modules/@keg-hub/tap-resolver
 

--- a/taps/tap-release-client/src/components/hocs/withAppHeader.js
+++ b/taps/tap-release-client/src/components/hocs/withAppHeader.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AppHeader } from '@keg-hub/keg-components'
+import { AppHeader } from '@old-keg-hub/keg-components'
 import { navigateBack } from 'SVActions/navigation/navigateBack'
 import { isRootStack } from 'SVNavigation/isRootStack'
 import { isStandalonePWA, isNative } from 'SVUtils/platform'


### PR DESCRIPTION
This fixes the issue EventsForce was facing with the `@keg-hub/keg-components` imports.

I also added a note to the README to deprecate this repository and point people toward `keg-hub/keg-hub` instead for the latest code.